### PR TITLE
new: added a way to pass additional arguments to kafka backed PubSubServer

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -1,11 +1,15 @@
 package bahamut
 
-import "time"
+import (
+	"time"
+
+	"github.com/Shopify/sarama"
+)
 
 // A PubSubServer is a structure that provides a publish/subscribe mechanism.
 type PubSubServer interface {
 	Publish(publication *Publication) error
-	Subscribe(pubs chan *Publication, errors chan error, topic string) func()
+	Subscribe(pubs chan *Publication, errors chan error, topic string, args ...interface{}) func()
 	Connect() Waiter
 	Disconnect()
 }
@@ -13,7 +17,13 @@ type PubSubServer interface {
 // NewKafkaPubSubServer returns a PubSubServer backed by Kafka.
 func NewKafkaPubSubServer(services []string) PubSubServer {
 
-	return newKafkaPubSub(services)
+	return newKafkaPubSub(services, nil)
+}
+
+// NewKafkaPubSubServerWithConfig returns a PubSubServer backed by Kafka using given Config.
+func NewKafkaPubSubServerWithConfig(services []string, config *sarama.Config) PubSubServer {
+
+	return newKafkaPubSub(services, config)
 }
 
 // NewLocalPubSubServer returns a PubSubServer backed by local channels.

--- a/pubsub_kafka_test.go
+++ b/pubsub_kafka_test.go
@@ -12,7 +12,7 @@ func TestKafka_NewPubSubServer(t *testing.T) {
 
 	Convey("Given I create a new PubSubServer", t, func() {
 
-		ps := newKafkaPubSub([]string{"123:123"})
+		ps := newKafkaPubSub([]string{"123:123"}, nil)
 
 		Convey("Then the PubSubServer should be correctly initialized", func() {
 			So(ps.services[0], ShouldEqual, "123:123")
@@ -35,7 +35,7 @@ func TestKafka_StartStop(t *testing.T) {
 		})
 		defer broker.Close()
 
-		ps := newKafkaPubSub([]string{})
+		ps := newKafkaPubSub([]string{}, nil)
 		ps.retryInterval = 1 * time.Millisecond
 
 		Convey("When I start the server", func() {
@@ -61,7 +61,7 @@ func TestKafka_StartStop(t *testing.T) {
 		})
 		defer broker.Close()
 
-		ps := newKafkaPubSub([]string{broker.Addr()})
+		ps := newKafkaPubSub([]string{broker.Addr()}, nil)
 
 		Convey("When I start the server", func() {
 
@@ -88,7 +88,7 @@ func TestKafka_Publish(t *testing.T) {
 
 	Convey("Given I try to publish while not connected", t, func() {
 
-		ps := newKafkaPubSub([]string{})
+		ps := newKafkaPubSub([]string{}, nil)
 
 		Convey("When I publish something", func() {
 
@@ -121,7 +121,7 @@ func TestKafka_Publish(t *testing.T) {
 		})
 		defer broker.Close()
 
-		ps := newKafkaPubSub([]string{broker.Addr()})
+		ps := newKafkaPubSub([]string{broker.Addr()}, nil)
 		ps.Connect().Wait(300 * time.Millisecond)
 
 		defer ps.Disconnect()
@@ -158,7 +158,7 @@ func TestKafka_Publish(t *testing.T) {
 		})
 		defer broker.Close()
 
-		ps := newKafkaPubSub([]string{broker.Addr()})
+		ps := newKafkaPubSub([]string{broker.Addr()}, nil)
 		ps.Connect().Wait(300 * time.Millisecond)
 
 		defer ps.Disconnect()
@@ -180,7 +180,7 @@ func TestKafka_Subscribe(t *testing.T) {
 
 	Convey("Given I try to subscribe but I cannot connect", t, func() {
 
-		ps := newKafkaPubSub([]string{})
+		ps := newKafkaPubSub([]string{}, nil)
 		ps.retryInterval = 1 * time.Millisecond
 
 		Convey("When I subscribe to something", func() {
@@ -211,7 +211,7 @@ func TestKafka_Subscribe(t *testing.T) {
 		})
 		defer broker.Close()
 
-		ps := newKafkaPubSub([]string{broker.Addr()})
+		ps := newKafkaPubSub([]string{broker.Addr()}, nil)
 
 		Convey("When I subscribe", func() {
 

--- a/pubsub_local.go
+++ b/pubsub_local.go
@@ -40,7 +40,7 @@ func (p *localPubSub) Publish(publication *Publication) error {
 }
 
 // Subscribe will subscribe the given channel to the given topic
-func (p *localPubSub) Subscribe(c chan *Publication, errors chan error, topic string) func() {
+func (p *localPubSub) Subscribe(c chan *Publication, errors chan error, topic string, args ...interface{}) func() {
 
 	unsubscribe := make(chan bool)
 


### PR DESCRIPTION
General:
- Additional arguments can be passed to the `PubSubServer.SubscribeMethod()` (uncontrolled)

Kafka Backed PubSubServer:
- Partition number can be passed as an optional arg to `Subscribe()`
- New constructor that allows to pass a `sarama.Config`