### PR TITLE
new: support for injecting open tracing tracker in publication [major]

### DIFF
--- a/publication.go
+++ b/publication.go
@@ -3,20 +3,30 @@ package bahamut
 import (
 	"bytes"
 	"encoding/json"
+
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/opentracing/opentracing-go/log"
+
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // Publication is a structure that can be published to a PublishServer.
 type Publication struct {
-	data      []byte
-	Topic     string
-	Partition int32
+	Data         json.RawMessage            `json:"data,omitempty"`
+	Topic        string                     `json:"topic,omitempty"`
+	Partition    int32                      `json:"partition,omitempty"`
+	TrackingName string                     `json:"trackingName,omitempty"`
+	TrackingData opentracing.TextMapCarrier `json:"trackingData,omitempty"`
+
+	span opentracing.Span
 }
 
 // NewPublication returns a new Publication.
 func NewPublication(topic string) *Publication {
 
 	return &Publication{
-		Topic: topic,
+		Topic:        topic,
+		TrackingData: opentracing.TextMapCarrier{},
 	}
 }
 
@@ -28,25 +38,95 @@ func (p *Publication) Encode(o interface{}) error {
 		return err
 	}
 
-	p.data = buffer.Bytes()
+	p.Data = buffer.Bytes()
+
+	if p.span != nil {
+		p.span.LogFields(log.Object("payload", string(p.Data)))
+	}
 
 	return nil
-}
-
-// SetData sets the raw data of the message.
-func (p *Publication) SetData(data []byte) {
-
-	p.data = data
-}
-
-// Data returns the raw data contained in the publication.
-func (p *Publication) Data() []byte {
-
-	return p.data
 }
 
 // Decode decodes the data into the given dest.
 func (p *Publication) Decode(dest interface{}) error {
 
-	return json.NewDecoder(bytes.NewReader(p.data)).Decode(&dest)
+	if p.span != nil {
+		p.span.LogFields(log.Object("payload", string(p.Data)))
+	}
+
+	return json.NewDecoder(bytes.NewReader(p.Data)).Decode(&dest)
+}
+
+// StartTracingFromSpan starts a new child opentracing.Span using the given span as parent.
+func (p *Publication) StartTracingFromSpan(span opentracing.Span, name string) error {
+
+	tracer := opentracing.GlobalTracer()
+	if tracer == nil {
+		return nil
+	}
+
+	p.span = opentracing.StartSpan(name, opentracing.ChildOf(span.Context()))
+	p.populateSpan()
+
+	return tracer.Inject(p.span.Context(), opentracing.TextMap, p.TrackingData)
+}
+
+// StartTracing starts a new tracer using wired data if any.
+func (p *Publication) StartTracing(name string) {
+
+	tracer := opentracing.GlobalTracer()
+	if tracer == nil {
+		return
+	}
+
+	wireContext, _ := tracer.Extract(opentracing.TextMap, opentracing.TextMapCarrier(p.TrackingData))
+
+	p.span = opentracing.StartSpan(name, ext.RPCServerOption(wireContext))
+	p.populateSpan()
+}
+
+// Span returns the current tracking span.
+func (p *Publication) Span() opentracing.Span {
+
+	return p.span
+}
+
+// SetSpanTag sets the tag of the inner span if any.
+func (p *Publication) SetSpanTag(key string, value interface{}) {
+
+	if p.span == nil {
+		return
+	}
+
+	p.span.SetTag(key, value)
+}
+
+// SetSpanLogs sets the logs of the inner span if any.
+func (p *Publication) SetSpanLogs(fields ...log.Field) {
+
+	if p.span == nil {
+		return
+	}
+
+	p.span.LogFields(fields...)
+}
+
+// FinishTracing will finish the publication tracing.
+func (p *Publication) FinishTracing() {
+
+	if p.span == nil {
+		return
+	}
+
+	p.span.Finish()
+}
+
+func (p *Publication) populateSpan() {
+
+	if p.span == nil {
+		return
+	}
+
+	p.span.SetTag("topic", p.Topic)
+	p.span.SetTag("partition", p.Partition)
 }

--- a/publication_test.go
+++ b/publication_test.go
@@ -37,7 +37,7 @@ func TestPublication_EncodeDecode(t *testing.T) {
 			})
 
 			Convey("Then the publication contains the correct data", func() {
-				So(string(publication.Data()), ShouldEqual, "{\"ID\":\"xxx\",\"creationOnly\":\"\",\"description\":\"\",\"name\":\"l1\",\"parentID\":\"\",\"parentType\":\"\",\"readOnly\":\"\"}\n")
+				So(string(publication.Data), ShouldEqual, "{\"ID\":\"xxx\",\"creationOnly\":\"\",\"description\":\"\",\"name\":\"l1\",\"parentID\":\"\",\"parentType\":\"\",\"readOnly\":\"\"}\n")
 			})
 
 			Convey("When I decode the object", func() {
@@ -55,15 +55,6 @@ func TestPublication_EncodeDecode(t *testing.T) {
 			})
 		})
 
-		Convey("When I manually set the data", func() {
-
-			publication.SetData([]byte("coucou"))
-
-			Convey("Then the publication contains the correct data", func() {
-				So(string(publication.Data()), ShouldEqual, "coucou")
-			})
-		})
-
 		Convey("When I encode some unencodable object", func() {
 
 			list := NewUnmarshalableList()
@@ -77,7 +68,7 @@ func TestPublication_EncodeDecode(t *testing.T) {
 			})
 
 			Convey("Then the publication contains the correct data", func() {
-				So(string(publication.Data()), ShouldEqual, "")
+				So(string(publication.Data), ShouldEqual, "")
 			})
 
 			Convey("When I decode the non existing object", func() {


### PR DESCRIPTION
This patch allows to send tracking information in bahamut.Publication.

In order to do so, it wires the open tracing span in the
bahamut.Publication object so it can be decoded after going through the
pubsub engine.

**BREAKING CHANGE** now the entire publication is sent to the PubSub,
and not only the publication data. This is the only way to carry the
needed additional information. All service publishing/subscribing using
a bahamut.PubSubServer must be using at least this version.