### PR TITLE
Fixed: when authorizating in mlts, do not return ok but continue. 

### DIFF
--- a/authorizer/mtls/authorizer.go
+++ b/authorizer/mtls/authorizer.go
@@ -91,7 +91,7 @@ func (a *mtlsVerifier) IsAuthorized(ctx *bahamut.Context) (bahamut.AuthAction, e
 	// If we can verify, we return the success auth action.
 	for _, cert := range ctx.Request.TLSConnectionState.PeerCertificates {
 		if _, err := cert.Verify(a.verifyOptions); err == nil {
-			return a.authActionSuccess, nil
+			return bahamut.AuthActionContinue, nil
 		}
 	}
 
@@ -109,7 +109,7 @@ func (a *mtlsVerifier) AuthenticateRequest(req *elemental.Request, claimsHolder 
 	for _, cert := range req.TLSConnectionState.PeerCertificates {
 		if _, err := cert.Verify(a.verifyOptions); err == nil {
 			claimsHolder.SetClaims(makeClaims(cert))
-			return a.authActionSuccess, nil
+			return bahamut.AuthActionContinue, nil
 		}
 	}
 

--- a/authorizer/mtls/authorizer_test.go
+++ b/authorizer/mtls/authorizer_test.go
@@ -91,7 +91,7 @@ func TestBahamut_MTLSAuthorizer(t *testing.T) {
 			})
 
 			Convey("Then action should be bahamut.AuthActionOK", func() {
-				So(action, ShouldEqual, bahamut.AuthActionOK)
+				So(action, ShouldEqual, bahamut.AuthActionContinue)
 			})
 		})
 
@@ -286,7 +286,7 @@ func TestBahamut_NewMTLSRequestAuthenticator(t *testing.T) {
 			})
 
 			Convey("Then action should be bahamut.AuthActionOK", func() {
-				So(action, ShouldEqual, bahamut.AuthActionOK)
+				So(action, ShouldEqual, bahamut.AuthActionContinue)
 			})
 
 			Convey("Then claims should be correctly populated", func() {


### PR DESCRIPTION
When returning OK, we force the system to not check other authorizer.

For instance, the following issue could happened:

- Connect to /1/2
- Retrieve the PU -> it works
- Delete /1/2
- Retrieve the PU from /1/2 was still working