### PR TITLE
Added StatusCode as span tag for non errors responses.

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -21,8 +21,7 @@ func makeResponse(ctx *bcontext, response *elemental.Response) *elemental.Respon
 
 	var fields []log.Field
 	defer func() {
-		span := opentracing.SpanFromContext(ctx.ctx)
-		if span != nil {
+		if span := opentracing.SpanFromContext(ctx.ctx); span != nil {
 			span.LogFields(fields...)
 			span.SetTag("status.code", response.StatusCode)
 		}


### PR DESCRIPTION
Today we are adding the reponse.StatusCode when processing an error:

in utils.go, processErrors:
```
	if span != nil {
		span.SetTag("error", true)
		span.SetTag("status.code", outError.Code())
		span.LogFields(log.Object("elemental.error", outError))
	}
```

This PR add the status code for normal response as a tag.