### PR TITLE
new: unit tests for PubSubClient NATS implementation Subscribe method

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,3 +9,7 @@
 [[constraint]]
   name = "github.com/golang/mock"
   version = "1.3.1"
+
+[[constraint]]
+  name = "github.com/nats-io/nats-server"
+  version = "1.4.1"


### PR DESCRIPTION
⚠️  this PR builds on https://github.com/aporeto-inc/bahamut/pull/52 therefore if it is accepted, it should be **merged *AFTER*** https://github.com/aporeto-inc/bahamut/pull/52 has been merged

---

This PR adds unit test coverage for the `Subscribe` method by bringing up a real NATS server on loopback interface as per suggested by the upstream NATS Go client maintainer [here](https://github.com/nats-io/nats.go/issues/467#issuecomment-493632703). This is actually how the upstream Go NATS client tests their implementation.

#### Scenarios covered:

- should successfully subscribe to topic and receive a publication in provided channel
- should NOT receive anything in publication channel that cannot be decoded into a publication
- should respond back with an ACK message to all publications that expect an ACK response
- should be able to set a custom response using the NATSOptSubscribeReplyer option to all publications that expect a response

