### PR TITLE
new: add ability for caller to get back received raw *nats.Msg to a channel

### DIFF
--- a/pubsub_nats.go
+++ b/pubsub_nats.go
@@ -75,16 +75,27 @@ func (p *natsPubSub) Publish(publication *Publication, opts ...PubSubOptPublish)
 		return fmt.Errorf("unable to encode publication. message dropped: %s", err)
 	}
 
-	if config.replyValidator == nil {
-		return p.client.Publish(publication.Topic, data)
+	if config.useRequestMode {
+
+		msg, err := p.client.RequestWithContext(config.ctx, publication.Topic, data)
+		if err != nil {
+			return err
+		}
+
+		if config.replyValidator != nil {
+			if err := config.replyValidator(msg); err != nil {
+				return err
+			}
+		}
+
+		if config.responseCh != nil {
+			config.responseCh <- msg
+		}
+
+		return nil
 	}
 
-	msg, err := p.client.RequestWithContext(config.ctx, publication.Topic, data)
-	if err != nil {
-		return err
-	}
-
-	return config.replyValidator(msg)
+	return p.client.Publish(publication.Topic, data)
 }
 
 func (p *natsPubSub) Subscribe(pubs chan *Publication, errors chan error, topic string, opts ...PubSubOptSubscribe) func() {

--- a/pubsub_nats.go
+++ b/pubsub_nats.go
@@ -89,7 +89,12 @@ func (p *natsPubSub) Publish(publication *Publication, opts ...PubSubOptPublish)
 		}
 
 		if config.responseCh != nil {
-			config.responseCh <- msg
+			responsePub := NewPublication("")
+			if err := elemental.Decode(elemental.EncodingTypeMSGPACK, msg.Data, responsePub); err != nil {
+				return err
+			}
+
+			config.responseCh <- responsePub
 		}
 
 		return nil

--- a/pubsub_nats_options.go
+++ b/pubsub_nats_options.go
@@ -78,6 +78,8 @@ type natsSubscribeConfig struct {
 type natsPublishConfig struct {
 	ctx            context.Context
 	replyValidator func(msg *nats.Msg) error
+	useRequestMode bool
+	responseCh     chan *nats.Msg
 }
 
 // NATSOptSubscribeQueue sets the NATS subscriber queue group.
@@ -107,6 +109,23 @@ func NATSOptSubscribeReplyer(replier func(msg *nats.Msg) []byte) PubSubOptSubscr
 	}
 }
 
+// NATSOptRespondToChannel will send the raw nats.Msg received to the provided channel.
+//
+// This is an advanced option which is useful in situations where you want to block until
+// you receive a response. The context parameter allows you to provide a deadline on how long
+// you should wait before considering the request as a failure:
+//
+//		myCtx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+//		respCh := make(chan *nats.Msg)
+// 		publishOption := NATSOptRespondToChannel(myCtx, respCh)
+func NATSOptRespondToChannel(ctx context.Context, resp chan *nats.Msg) PubSubOptPublish {
+	return func(c interface{}) {
+		c.(*natsPublishConfig).useRequestMode = true
+		c.(*natsPublishConfig).ctx = ctx
+		c.(*natsPublishConfig).responseCh = resp
+	}
+}
+
 // NATSOptPublishReplyValidator sets the function that will be called to validate
 // a request reply.
 //
@@ -118,6 +137,7 @@ func NATSOptSubscribeReplyer(replier func(msg *nats.Msg) []byte) PubSubOptSubscr
 // See: https://nats.io/documentation/concepts/nats-req-rep/
 func NATSOptPublishReplyValidator(ctx context.Context, validator func(msg *nats.Msg) error) PubSubOptPublish {
 	return func(c interface{}) {
+		c.(*natsPublishConfig).useRequestMode = true
 		c.(*natsPublishConfig).replyValidator = validator
 		c.(*natsPublishConfig).ctx = ctx
 	}

--- a/pubsub_nats_options.go
+++ b/pubsub_nats_options.go
@@ -79,7 +79,7 @@ type natsPublishConfig struct {
 	ctx            context.Context
 	replyValidator func(msg *nats.Msg) error
 	useRequestMode bool
-	responseCh     chan *nats.Msg
+	responseCh     chan *Publication
 }
 
 // NATSOptSubscribeQueue sets the NATS subscriber queue group.
@@ -109,16 +109,16 @@ func NATSOptSubscribeReplyer(replier func(msg *nats.Msg) []byte) PubSubOptSubscr
 	}
 }
 
-// NATSOptRespondToChannel will send the raw nats.Msg received to the provided channel.
+// NATSOptRespondToChannel will send the *Publication received to the provided channel.
 //
 // This is an advanced option which is useful in situations where you want to block until
 // you receive a response. The context parameter allows you to provide a deadline on how long
 // you should wait before considering the request as a failure:
 //
 //		myCtx, _ := context.WithTimeout(context.Background(), 5*time.Second)
-//		respCh := make(chan *nats.Msg)
+//		respCh := make(chan *Publication)
 // 		publishOption := NATSOptRespondToChannel(myCtx, respCh)
-func NATSOptRespondToChannel(ctx context.Context, resp chan *nats.Msg) PubSubOptPublish {
+func NATSOptRespondToChannel(ctx context.Context, resp chan *Publication) PubSubOptPublish {
 	return func(c interface{}) {
 		c.(*natsPublishConfig).useRequestMode = true
 		c.(*natsPublishConfig).ctx = ctx


### PR DESCRIPTION
## Issue: https://github.com/aporeto-inc/aporeto/issues/1274

This PR introduces a new option to the NATS pubsub `Publish` method: `NATSOptRespondToChannel`

This option allows clients to receive the response `*Publication` to a channel they configure when using the [NATS request-reply messaging pattern](https://nats.io/documentation/concepts/nats-req-rep/). This is particularly useful in situations where the client is publishing something within an HTTP handler and they need to block and wait for a reply so they can use the response message to craft an appropriate HTTP response (_e.g. Aporeto automations handling webhooks!_).

#### Sample usage:

```go

	responseCh := make(chan *Publication)
	errorCh := make(chan error)

	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
	defer cancel()

	go func() {
		if err := p.pubsub.Publish(pub, bahamut.NATSOptRespondToChannel(ctx, responseCh)); err != nil {
			errorCh <- err
		}
	}()

	select {
	case response := <-responseCh:
		fmt.Printf("received a message: %+v\n", response)
	case err := <-errorCh:
		fmt.Printf("received an error: %+v\n", err)
	}
```


#### Other things

- This option is backwards compatible with existing logic. 
- New unit tests added ✅ 


---

👀Review: @primalmotion @t00f 