### PR TITLE
NATS PubSub - add ability to send an ACK request prior to making a request

### DIFF
--- a/pubsub_nats_options.go
+++ b/pubsub_nats_options.go
@@ -68,7 +68,10 @@ func natsOptClient(client natsClient) NATSOption {
 	}
 }
 
-var ackMessage = []byte("ack")
+var (
+	ackRequest = []byte("ack-request")
+	ackMessage = []byte("ack")
+)
 
 type natsSubscribeConfig struct {
 	queueGroup string
@@ -78,6 +81,8 @@ type natsSubscribeConfig struct {
 type natsPublishConfig struct {
 	ctx            context.Context
 	replyValidator func(msg *nats.Msg) error
+
+	sendAckReq     bool
 	useRequestMode bool
 	responseCh     chan *Publication
 }
@@ -126,6 +131,9 @@ func NATSOptRespondToChannel(ctx context.Context, resp chan *Publication) PubSub
 	}
 }
 
+// DEPRECATED: use NATSOptPublishRequireAck and/or NATSOptRespondToChannel instead;
+// this option will be removed in a future release
+//
 // NATSOptPublishReplyValidator sets the function that will be called to validate
 // a request reply.
 //
@@ -151,6 +159,7 @@ func NATSOptPublishReplyValidator(ctx context.Context, validator func(msg *nats.
 // the option NATSOptPublishReplyValidator.
 func NATSOptPublishRequireAck(ctx context.Context) PubSubOptPublish {
 	return func(c interface{}) {
+		c.(*natsPublishConfig).sendAckReq = true
 		c.(*natsPublishConfig).replyValidator = ackValidator
 		c.(*natsPublishConfig).ctx = ctx
 	}


### PR DESCRIPTION
This PR builds on https://github.com/aporeto-inc/bahamut/pull/56 and adds the ability for clients to request an ACK response prior to making their request.

**Scenario:** I am making a request which I expect will take a long time. I don't want to wait until my preconfigured timeout is reached if the service handling the topic I am publishing to is not even up. In such cases, I should be able to send an **ACK-Request** and upon acknowledgement, I can then proceed to make my request.

```go
        // notice how this timeout is SMALL
        ackCtx, _ := context.WithTimeout(context.Background(), 1*time.Second)
        // notice how this timeout is BIG
        reqCtx, _ := context.WithTimeout(context.Background(), 10*time.Second)

	p.pubsub.Publish(pub,
		bahamut.NATSOptPublishRequireAck(ackCtx),
		bahamut.NATSOptRespondToChannel(reqCtx, responseCh)
	)
```

_Related to: https://github.com/aporeto-inc/aporeto/issues/1274_

## TODO: 

- [ ] Get feedback from @primalmotion & @t00f 
- [ ] Unit test coverage for when ACK request fails
- [ ] Unit test coverage for when ACK requests succeeds, but the response is invalid 


