### PR TITLE
NATS PubSub  - adds ability to distinguish between different Publish requests

### DIFF
--- a/publication.go
+++ b/publication.go
@@ -22,6 +22,19 @@ import (
 // handling a publication.
 type ResponseMode int
 
+func (r ResponseMode) String() string {
+	switch r {
+	case ResponseModeNone:
+		return "ResponseModeNone"
+	case ResponseModeACK:
+		return "ResponseModeACK"
+	case ResponseModePublication:
+		return "ResponseModePublication"
+	default:
+		return "ResponseModeUnknown"
+	}
+}
+
 const (
 	// ResponseModeNone indicates that no response is expected for the received publication
 	ResponseModeNone ResponseMode = iota

--- a/publication.go
+++ b/publication.go
@@ -23,10 +23,12 @@ import (
 type ResponseMode int
 
 const (
+	// ResponseModeNone indicates that no response is expected for the received publication
+	ResponseModeNone ResponseMode = iota
 	// ResponseModeACK indicates that the subscriber should reply back with an ACK
 	// as soon as it has received the publication BEFORE it starts processing the
 	// publication.
-	ResponseModeACK ResponseMode = iota + 1
+	ResponseModeACK
 	// ResponseModePublication indicates that the subscriber should reply back with a
 	// Publication AFTER it has finished processing the publication. Obviously, the
 	// subscriber should try to respond ASAP as there is a client waiting for a response.

--- a/publication.go
+++ b/publication.go
@@ -23,14 +23,14 @@ import (
 type ResponseMode int
 
 const (
-	// ReplyWithACK indicates that the subscriber should reply back with an ACK
+	// ResponseModeACK indicates that the subscriber should reply back with an ACK
 	// as soon as it has received the publication BEFORE it starts processing the
 	// publication.
-	ReplyWithACK ResponseMode = iota + 1
-	// ReplyWithPublication indicates that the subscriber should reply back with a
+	ResponseModeACK ResponseMode = iota + 1
+	// ResponseModePublication indicates that the subscriber should reply back with a
 	// Publication AFTER it has finished processing the publication. Obviously, the
 	// subscriber should try to respond ASAP as there is a client waiting for a response.
-	ReplyWithPublication
+	ResponseModePublication
 )
 
 // Publication is a structure that can be published to a PublishServer.

--- a/publication.go
+++ b/publication.go
@@ -18,6 +18,21 @@ import (
 	"go.aporeto.io/elemental"
 )
 
+// ResponseMode represents the response that is expected to be produced by the subscriber
+// handling a publication.
+type ResponseMode int
+
+const (
+	// ReplyWithACK indicates that the subscriber should reply back with an ACK
+	// as soon as it has received the publication BEFORE it starts processing the
+	// publication.
+	ReplyWithACK ResponseMode = iota + 1
+	// ReplyWithPublication indicates that the subscriber should reply back with a
+	// Publication AFTER it has finished processing the publication. Obviously, the
+	// subscriber should try to respond ASAP as there is a client waiting for a response.
+	ReplyWithPublication
+)
+
 // Publication is a structure that can be published to a PublishServer.
 type Publication struct {
 	Data         []byte                     `msgpack:"data,omitempty" json:"data,omitempty"`
@@ -26,6 +41,7 @@ type Publication struct {
 	TrackingName string                     `msgpack:"trackingName,omitempty" json:"trackingName,omitempty"`
 	TrackingData opentracing.TextMapCarrier `msgpack:"trackingData,omitempty" json:"trackingData,omitempty"`
 	Encoding     elemental.EncodingType     `msgpack:"encoding,omitempty" json:"encoding,omitempty"`
+	ResponseMode ResponseMode               `msgpack:"responseMode,omitempty" json:"responseMode,omitempty"`
 
 	span opentracing.Span
 }
@@ -116,8 +132,9 @@ func (p *Publication) Duplicate() *Publication {
 	pub.Partition = p.Partition
 	pub.TrackingName = p.TrackingName
 	pub.TrackingData = p.TrackingData
-	pub.span = p.span
 	pub.Encoding = p.Encoding
+	pub.ResponseMode = p.ResponseMode
+	pub.span = p.span
 
 	return pub
 }

--- a/pubsub_nats.go
+++ b/pubsub_nats.go
@@ -76,6 +76,8 @@ func (p *natsPubSub) Publish(publication *Publication, opts ...PubSubOptPublish)
 		publication.ResponseMode = ResponseModeACK
 	case requestModePublication:
 		publication.ResponseMode = ResponseModePublication
+	default:
+		publication.ResponseMode = ResponseModeNone
 	}
 
 	data, err := elemental.Encode(elemental.EncodingTypeMSGPACK, publication)

--- a/pubsub_nats.go
+++ b/pubsub_nats.go
@@ -72,10 +72,10 @@ func (p *natsPubSub) Publish(publication *Publication, opts ...PubSubOptPublish)
 	}
 
 	switch config.requestMode {
-	case waitForACK:
-		publication.ResponseMode = ReplyWithACK
-	case waitForPublication:
-		publication.ResponseMode = ReplyWithPublication
+	case requestModeACK:
+		publication.ResponseMode = ResponseModeACK
+	case requestModePublication:
+		publication.ResponseMode = ResponseModePublication
 	}
 
 	data, err := elemental.Encode(elemental.EncodingTypeMSGPACK, publication)
@@ -84,7 +84,7 @@ func (p *natsPubSub) Publish(publication *Publication, opts ...PubSubOptPublish)
 	}
 
 	switch config.requestMode {
-	case waitForACK, waitForPublication:
+	case requestModeACK, requestModePublication:
 
 		msg, err := p.client.RequestWithContext(config.ctx, publication.Topic, data)
 		if err != nil {
@@ -95,13 +95,13 @@ func (p *natsPubSub) Publish(publication *Publication, opts ...PubSubOptPublish)
 			return err
 		}
 
-		if config.requestMode == waitForACK {
+		if config.requestMode == requestModeACK {
 			if !bytes.Equal(msg.Data, ackMessage) {
 				return fmt.Errorf("invalid ack: %s", string(msg.Data))
 			}
 		}
 
-		if config.requestMode == waitForPublication && config.responseCh != nil {
+		if config.requestMode == requestModePublication && config.responseCh != nil {
 			responsePub := NewPublication("")
 			if err := elemental.Decode(elemental.EncodingTypeMSGPACK, msg.Data, responsePub); err != nil {
 				return err

--- a/pubsub_nats.go
+++ b/pubsub_nats.go
@@ -71,10 +71,10 @@ func (p *natsPubSub) Publish(publication *Publication, opts ...PubSubOptPublish)
 		opt(&config)
 	}
 
-	switch config.requestMode {
-	case requestModeACK:
+	switch config.desiredResponse {
+	case ResponseModeACK:
 		publication.ResponseMode = ResponseModeACK
-	case requestModePublication:
+	case ResponseModePublication:
 		publication.ResponseMode = ResponseModePublication
 	default:
 		publication.ResponseMode = ResponseModeNone
@@ -85,8 +85,8 @@ func (p *natsPubSub) Publish(publication *Publication, opts ...PubSubOptPublish)
 		return fmt.Errorf("unable to encode publication. message dropped: %s", err)
 	}
 
-	switch config.requestMode {
-	case requestModeACK, requestModePublication:
+	switch config.desiredResponse {
+	case ResponseModeACK, ResponseModePublication:
 
 		msg, err := p.client.RequestWithContext(config.ctx, publication.Topic, data)
 		if err != nil {
@@ -97,13 +97,13 @@ func (p *natsPubSub) Publish(publication *Publication, opts ...PubSubOptPublish)
 			return err
 		}
 
-		if config.requestMode == requestModeACK {
+		if config.desiredResponse == ResponseModeACK {
 			if !bytes.Equal(msg.Data, ackMessage) {
 				return fmt.Errorf("invalid ack: %s", string(msg.Data))
 			}
 		}
 
-		if config.requestMode == requestModePublication && config.responseCh != nil {
+		if config.desiredResponse == ResponseModePublication {
 			responsePub := NewPublication("")
 			if err := elemental.Decode(elemental.EncodingTypeMSGPACK, msg.Data, responsePub); err != nil {
 				return err

--- a/pubsub_nats_options.go
+++ b/pubsub_nats_options.go
@@ -22,8 +22,8 @@ import (
 type requestMode int
 
 const (
-	waitForACK requestMode = iota + 1
-	waitForPublication
+	requestModeACK requestMode = iota + 1
+	requestModePublication
 )
 
 // A NATSOption represents an option to the pubsub backed by nats
@@ -126,7 +126,7 @@ func NATSOptRespondToChannel(ctx context.Context, resp chan *Publication) PubSub
 	return func(c interface{}) {
 		c.(*natsPublishConfig).ctx = ctx
 		c.(*natsPublishConfig).responseCh = resp
-		c.(*natsPublishConfig).requestMode = waitForPublication
+		c.(*natsPublishConfig).requestMode = requestModePublication
 	}
 }
 
@@ -139,6 +139,6 @@ func NATSOptRespondToChannel(ctx context.Context, resp chan *Publication) PubSub
 func NATSOptPublishRequireAck(ctx context.Context) PubSubOptPublish {
 	return func(c interface{}) {
 		c.(*natsPublishConfig).ctx = ctx
-		c.(*natsPublishConfig).requestMode = waitForACK
+		c.(*natsPublishConfig).requestMode = requestModeACK
 	}
 }

--- a/pubsub_nats_options_test.go
+++ b/pubsub_nats_options_test.go
@@ -72,11 +72,36 @@ func TestBahamut_PubSubNatsOptionsSubscribe(t *testing.T) {
 
 func TestBahamut_PubSubNatsOptionsPublish(t *testing.T) {
 
-	c := natsPublishConfig{}
+	Convey("Setup", t, func() {
 
-	Convey("Calling NATSOptPublishRequireAck should work", t, func() {
-		NATSOptPublishRequireAck(context.TODO())(&c)
-		So(c.ctx, ShouldEqual, context.TODO())
-		So(c.requestMode, ShouldEqual, requestModeACK)
+		c := natsPublishConfig{}
+
+		Convey("Calling NATSOptPublishRequireAck should work", func() {
+			NATSOptPublishRequireAck(context.TODO())(&c)
+			So(c.ctx, ShouldEqual, context.TODO())
+			So(c.requestMode, ShouldEqual, requestModeACK)
+		})
+
+		Convey("Calling NATSOptPublishRequireAck should panic if requestMode has already been set", func() {
+			c.requestMode = requestModePublication
+			So(func() {
+				NATSOptPublishRequireAck(context.TODO())(&c)
+			}, ShouldPanic)
+		})
+
+		Convey("Calling NATSOptRespondToChannel should work", func() {
+			respCh := make(chan *Publication)
+			NATSOptRespondToChannel(context.TODO(), respCh)(&c)
+			So(c.ctx, ShouldEqual, context.TODO())
+			So(c.responseCh, ShouldEqual, respCh)
+			So(c.requestMode, ShouldEqual, requestModePublication)
+		})
+
+		Convey("Calling NATSOptRespondToChannel should panic if requestMode has already been set", func() {
+			c.requestMode = requestModeACK
+			So(func() {
+				NATSOptRespondToChannel(context.TODO(), make(chan *Publication))(&c)
+			}, ShouldPanic)
+		})
 	})
 }

--- a/pubsub_nats_options_test.go
+++ b/pubsub_nats_options_test.go
@@ -77,6 +77,6 @@ func TestBahamut_PubSubNatsOptionsPublish(t *testing.T) {
 	Convey("Calling NATSOptPublishRequireAck should work", t, func() {
 		NATSOptPublishRequireAck(context.TODO())(&c)
 		So(c.ctx, ShouldEqual, context.TODO())
-		So(c.requestMode, ShouldEqual, waitForACK)
+		So(c.requestMode, ShouldEqual, requestModeACK)
 	})
 }

--- a/pubsub_nats_options_test.go
+++ b/pubsub_nats_options_test.go
@@ -79,13 +79,20 @@ func TestBahamut_PubSubNatsOptionsPublish(t *testing.T) {
 		Convey("Calling NATSOptPublishRequireAck should work", func() {
 			NATSOptPublishRequireAck(context.TODO())(&c)
 			So(c.ctx, ShouldEqual, context.TODO())
-			So(c.requestMode, ShouldEqual, requestModeACK)
+			So(c.desiredResponse, ShouldEqual, ResponseModeACK)
 		})
 
 		Convey("Calling NATSOptPublishRequireAck should panic if requestMode has already been set", func() {
-			c.requestMode = requestModePublication
+			c.desiredResponse = ResponseModePublication
 			So(func() {
 				NATSOptPublishRequireAck(context.TODO())(&c)
+			}, ShouldPanic)
+		})
+
+		Convey("Calling NATSOptPublishRequireAck should panic if supplied context is nil", func() {
+			So(func() {
+				// nolint - note: ignoring linter feedback as we are trying to cause a panic intentionally by passing in a `nil` context
+				NATSOptPublishRequireAck(nil)(&c)
 			}, ShouldPanic)
 		})
 
@@ -94,13 +101,27 @@ func TestBahamut_PubSubNatsOptionsPublish(t *testing.T) {
 			NATSOptRespondToChannel(context.TODO(), respCh)(&c)
 			So(c.ctx, ShouldEqual, context.TODO())
 			So(c.responseCh, ShouldEqual, respCh)
-			So(c.requestMode, ShouldEqual, requestModePublication)
+			So(c.desiredResponse, ShouldEqual, ResponseModePublication)
 		})
 
 		Convey("Calling NATSOptRespondToChannel should panic if requestMode has already been set", func() {
-			c.requestMode = requestModeACK
+			c.desiredResponse = ResponseModeACK
 			So(func() {
 				NATSOptRespondToChannel(context.TODO(), make(chan *Publication))(&c)
+			}, ShouldPanic)
+		})
+
+		Convey("Calling NATSOptRespondToChannel should panic if supplied response channel is nil", func() {
+			So(func() {
+				NATSOptRespondToChannel(context.TODO(), nil)(&c)
+			}, ShouldPanic)
+		})
+
+		Convey("Calling NATSOptRespondToChannel should panic if supplied context is nil", func() {
+			c.desiredResponse = ResponseModeACK
+			So(func() {
+				// nolint - note: ignoring linter feedback as we are trying to cause a panic intentionally by passing in a `nil` context
+				NATSOptRespondToChannel(nil, make(chan *Publication))(&c)
 			}, ShouldPanic)
 		})
 	})

--- a/pubsub_nats_options_test.go
+++ b/pubsub_nats_options_test.go
@@ -74,17 +74,9 @@ func TestBahamut_PubSubNatsOptionsPublish(t *testing.T) {
 
 	c := natsPublishConfig{}
 
-	Convey("Calling NATSOptPublishReplyValidator should work", t, func() {
-		v := func(msg *nats.Msg) error { return nil }
-		NATSOptPublishReplyValidator(context.TODO(), v)(&c)
-		So(c.ctx, ShouldEqual, context.TODO())
-		So(c.replyValidator, ShouldEqual, v)
-	})
-
 	Convey("Calling NATSOptPublishRequireAck should work", t, func() {
 		NATSOptPublishRequireAck(context.TODO())(&c)
 		So(c.ctx, ShouldEqual, context.TODO())
-		So(c.replyValidator(&nats.Msg{Data: ackMessage}), ShouldEqual, nil)
-		So(c.replyValidator(&nats.Msg{Data: []byte("hello")}).Error(), ShouldEqual, "invalid ack: hello")
+		So(c.requestMode, ShouldEqual, waitForACK)
 	})
 }

--- a/pubsub_nats_test.go
+++ b/pubsub_nats_test.go
@@ -288,6 +288,45 @@ func TestPublish(t *testing.T) {
 				}, func() {}
 			},
 		},
+		{
+			description: "should return an error if response is not a valid ACK response when using the NATSOptPublishRequireAck option",
+			publication: NewPublication("test topic"),
+			setup: func(t *testing.T, mockClient *mocks.MockNATSClient, pub *Publication) {
+				mockClient.
+					EXPECT().
+					Publish(gomock.Any(), gomock.Any()).
+					// should never be called in this case as passing in the NATSOptPublishReplyValidator
+					// will cause Publish to use the Request-Reply pattern that is synchronous (i.e. will not
+					// return until a response is returned or we timeout waiting for one)
+					// See Request-Reply: https://nats.io/documentation/writing_applications/publishing/
+					Times(0)
+
+				// note: passing in the NATSOptPublishRequireAck option should set the publication response mode
+				// to ACK before encoding the publication
+				pub.ResponseMode = ReplyWithACK
+				expectedData, err := elemental.Encode(elemental.EncodingTypeMSGPACK, pub)
+				if err != nil {
+					t.Fatalf("test setup failed - could not encode publication - error: %+v", err)
+					return
+				}
+
+				// notice how the response is not a valid ACK response!
+				mockClient.
+					EXPECT().
+					RequestWithContext(gomock.Any(), pub.Topic, expectedData).
+					Return(&nats.Msg{
+						Data: []byte("this is not a valid ACK response!"),
+					}, nil).
+					Times(1)
+			},
+			expectedErrType: errors.New(""),
+			natsOptions:     []NATSOption{},
+			publishOptionsGenerator: func(t *testing.T) ([]PubSubOptPublish, func()) {
+				return []PubSubOptPublish{
+					NATSOptPublishRequireAck(context.Background()),
+				}, func() {}
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pubsub_nats_test.go
+++ b/pubsub_nats_test.go
@@ -120,7 +120,7 @@ func TestPublish(t *testing.T) {
 
 				// note: passing in the NATSOptRespondToChannel option should set the publication response mode
 				// to ReplyWithPublication before encoding the publication
-				pub.ResponseMode = ReplyWithPublication
+				pub.ResponseMode = ResponseModePublication
 				expectedPublishData, err := elemental.Encode(elemental.EncodingTypeMSGPACK, pub)
 				if err != nil {
 					t.Fatalf("test setup failed - could not encode publication - error: %+v", err)
@@ -174,7 +174,7 @@ func TestPublish(t *testing.T) {
 
 				// note: passing in the NATSOptRespondToChannel option should set the publication response mode
 				// to ReplyWithPublication before encoding the publication
-				pub.ResponseMode = ReplyWithPublication
+				pub.ResponseMode = ResponseModePublication
 				expectedPublishData, err := elemental.Encode(elemental.EncodingTypeMSGPACK, pub)
 				if err != nil {
 					t.Fatalf("test setup failed - could not encode publication - error: %+v", err)
@@ -266,7 +266,7 @@ func TestPublish(t *testing.T) {
 
 				// note: passing in the NATSOptPublishRequireAck option should set the publication response mode
 				// to ACK before encoding the publication
-				pub.ResponseMode = ReplyWithACK
+				pub.ResponseMode = ResponseModeACK
 				expectedData, err := elemental.Encode(elemental.EncodingTypeMSGPACK, pub)
 				if err != nil {
 					t.Fatalf("test setup failed - could not encode publication - error: %+v", err)
@@ -303,7 +303,7 @@ func TestPublish(t *testing.T) {
 
 				// note: passing in the NATSOptPublishRequireAck option should set the publication response mode
 				// to ACK before encoding the publication
-				pub.ResponseMode = ReplyWithACK
+				pub.ResponseMode = ResponseModeACK
 				expectedData, err := elemental.Encode(elemental.EncodingTypeMSGPACK, pub)
 				if err != nil {
 					t.Fatalf("test setup failed - could not encode publication - error: %+v", err)

--- a/pubsub_nats_test.go
+++ b/pubsub_nats_test.go
@@ -118,6 +118,9 @@ func TestPublish(t *testing.T) {
 					Publish(gomock.Any(), gomock.Any()).
 					Times(0)
 
+				// note: passing in the NATSOptRespondToChannel option should set the publication response mode
+				// to ReplyWithPublication before encoding the publication
+				pub.ResponseMode = ReplyWithPublication
 				expectedPublishData, err := elemental.Encode(elemental.EncodingTypeMSGPACK, pub)
 				if err != nil {
 					t.Fatalf("test setup failed - could not encode publication - error: %+v", err)
@@ -169,6 +172,9 @@ func TestPublish(t *testing.T) {
 					Publish(gomock.Any(), gomock.Any()).
 					Times(0)
 
+				// note: passing in the NATSOptRespondToChannel option should set the publication response mode
+				// to ReplyWithPublication before encoding the publication
+				pub.ResponseMode = ReplyWithPublication
 				expectedPublishData, err := elemental.Encode(elemental.EncodingTypeMSGPACK, pub)
 				if err != nil {
 					t.Fatalf("test setup failed - could not encode publication - error: %+v", err)
@@ -246,82 +252,6 @@ func TestPublish(t *testing.T) {
 			natsOptions:     []NATSOption{},
 		},
 		{
-			description: "should be able to provide a custom reply validator using the NATSOptPublishRequireAck option",
-			publication: NewPublication("test topic"),
-			setup: func(t *testing.T, mockClient *mocks.MockNATSClient, pub *Publication) {
-				mockClient.
-					EXPECT().
-					Publish(gomock.Any(), gomock.Any()).
-					// should never be called in this case as passing in the NATSOptPublishReplyValidator
-					// will cause Publish to use the Request-Reply pattern that is synchronous (i.e. will not
-					// return until a response is returned or we timeout waiting for one)
-					// See Request-Reply: https://nats.io/documentation/writing_applications/publishing/
-					Times(0)
-
-				expectedData, err := elemental.Encode(elemental.EncodingTypeMSGPACK, pub)
-				if err != nil {
-					t.Fatalf("test setup failed - could not encode publication - error: %+v", err)
-					return
-				}
-
-				mockClient.
-					EXPECT().
-					RequestWithContext(gomock.Any(), pub.Topic, expectedData).
-					Return(&nats.Msg{
-						Data: []byte("helloworld"),
-					}, nil).
-					Times(1)
-			},
-			expectedErrType: nil,
-			natsOptions:     []NATSOption{},
-			publishOptionsGenerator: func(t *testing.T) ([]PubSubOptPublish, func()) {
-				return []PubSubOptPublish{
-					// this is a friendly validator, it always passes successfully!
-					NATSOptPublishReplyValidator(context.Background(), func(_ *nats.Msg) error {
-						return nil
-					}),
-				}, func() {}
-			},
-		},
-		{
-			description: "should return an error if custom response validator fails response message validation",
-			publication: NewPublication("test topic"),
-			setup: func(t *testing.T, mockClient *mocks.MockNATSClient, pub *Publication) {
-				mockClient.
-					EXPECT().
-					Publish(gomock.Any(), gomock.Any()).
-					// should never be called in this case as passing in the NATSOptPublishReplyValidator
-					// will cause Publish to use the Request-Reply pattern that is synchronous (i.e. will not
-					// return until a response is returned or we timeout waiting for one)
-					// See Request-Reply: https://nats.io/documentation/writing_applications/publishing/
-					Times(0)
-
-				expectedData, err := elemental.Encode(elemental.EncodingTypeMSGPACK, pub)
-				if err != nil {
-					t.Fatalf("test setup failed - could not encode publication - error: %+v", err)
-					return
-				}
-
-				mockClient.
-					EXPECT().
-					RequestWithContext(gomock.Any(), pub.Topic, expectedData).
-					Return(&nats.Msg{
-						Data: []byte("helloworld"),
-					}, nil).
-					Times(1)
-			},
-			expectedErrType: errors.New(""),
-			natsOptions:     []NATSOption{},
-			publishOptionsGenerator: func(t *testing.T) ([]PubSubOptPublish, func()) {
-				return []PubSubOptPublish{
-					// this is a friendly validator, it always passes successfully!
-					NATSOptPublishReplyValidator(context.Background(), func(_ *nats.Msg) error {
-						return errors.New("message validation failed :-(")
-					}),
-				}, func() {}
-			},
-		},
-		{
 			description: "should return an error if RequestWithContext returns an error",
 			publication: NewPublication("test topic"),
 			setup: func(t *testing.T, mockClient *mocks.MockNATSClient, pub *Publication) {
@@ -334,6 +264,9 @@ func TestPublish(t *testing.T) {
 					// See Request-Reply: https://nats.io/documentation/writing_applications/publishing/
 					Times(0)
 
+				// note: passing in the NATSOptPublishRequireAck option should set the publication response mode
+				// to ACK before encoding the publication
+				pub.ResponseMode = ReplyWithACK
 				expectedData, err := elemental.Encode(elemental.EncodingTypeMSGPACK, pub)
 				if err != nil {
 					t.Fatalf("test setup failed - could not encode publication - error: %+v", err)
@@ -351,10 +284,7 @@ func TestPublish(t *testing.T) {
 			natsOptions:     []NATSOption{},
 			publishOptionsGenerator: func(t *testing.T) ([]PubSubOptPublish, func()) {
 				return []PubSubOptPublish{
-					// this is a friendly validator, it always passes successfully!
-					NATSOptPublishReplyValidator(context.Background(), func(_ *nats.Msg) error {
-						return nil
-					}),
+					NATSOptPublishRequireAck(context.Background()),
 				}, func() {}
 			},
 		},


### PR DESCRIPTION
## Parent issue: https://github.com/aporeto-inc/aporeto/issues/1274

## Context

This PR adds the ability to distinguish between different Publish requests when using the NATS request-reply messaging pattern. Our existing `PubSubOptPublish` options are impacted as follows: 

#### `NATSOptPublishRequireAck` option 

When configured, it will set the ResponseMode field of the Publication to “ReplyWithACK”. The side effect of this is that caller of Publish will now block until an ACK is received or the supplied context deadline is reached. As a result of this option our implementation of Subscribe will now need to look for this new ResponseMode attribute when consuming messages to determine whether it needs to respond back with an ACK - the value would be set to “ReplyWithACK”. This option is mutually exclusive with the `NATSOptRespondToChannel` option.

#### `NATSOptRespondToChannel` option 

When configured, it will set the ResponseMode field of the Publication to “ReplyWithPublication”. The side effect of this is that caller of Publish will now block until a Publication response is received or the supplied context deadline is reached. As a result of this option our implementation of Subscribe will now need to look for the new ResponseMode attribute and check to see if its value is set to “ReplyWithPublication” as this would imply that a Publication response should be delivered AFTER processing has been completed. This option is mutually exclusive with the `NATSOptPublishRequireAck` option.

### ⚠️ Breaking change(s)

- removed the `NATSOptPublishReplyValidator` publish option as it now serves no purpose. Folks should either use `NATSOptPublishRequireAck` or `NATSOptRespondToChannel` now. As a result, the `replyValidator` attribute from the publish configuration has been removed as well.

### If merged, will this break 💥 existing consumers?

This changes introduced here _should not break™_ existing clients after they upgrade their Bahamut package (_asides for the breaking change mentioned above_). The existing `Subscribe` implementation should work as is because [currently it is just checking whether the received raw `*nats.Msg` type it gets has a `Reply` attribute set](https://github.com/aporeto-inc/bahamut/blob/master/pubsub_nats.go#L124). If it does, it uses the value in that field as the subject to send back an ACK reply to.

## Coming next

Modify our `Subscribe` implementation to distinguish between the expected `ResponseMode` which is now serialized into the `Publication`. The `Subscribe` implementation should check this field and behave accordingly:

- If the expected response mode is an ACK, it should reply back straight away before processing the publication
- If the expected response mode is a Publication, it should process the received publication first and then respond back with another publication. Perhaps the client code can utilize a new convenience method here on the `Publication` type? e.g. "Reply" or something similar.
