### PR TITLE
new: add ability for subscriber to respond back to publication AFTER processing

### DIFF
--- a/publication.go
+++ b/publication.go
@@ -12,6 +12,8 @@
 package bahamut
 
 import (
+	"errors"
+
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
@@ -58,7 +60,8 @@ type Publication struct {
 	Encoding     elemental.EncodingType     `msgpack:"encoding,omitempty" json:"encoding,omitempty"`
 	ResponseMode ResponseMode               `msgpack:"responseMode,omitempty" json:"responseMode,omitempty"`
 
-	span opentracing.Span
+	replyCh chan<- *Publication
+	span    opentracing.Span
 }
 
 // NewPublication returns a new Publication.
@@ -152,4 +155,19 @@ func (p *Publication) Duplicate() *Publication {
 	pub.span = p.span
 
 	return pub
+}
+
+// Reply will publish the provided publication back to the client. An error is returned if
+// the client was not expecting a response. If you take too long to reply to a publication
+// an error may be returned in the errors channel you provided in your call to the `Subscribe`
+// method as the client may have given up waiting for your response.
+func (p *Publication) Reply(response *Publication) error {
+
+	if p.replyCh == nil {
+		return errors.New("no response required for publication")
+	}
+
+	p.replyCh <- response
+
+	return nil
 }

--- a/publication.go
+++ b/publication.go
@@ -13,8 +13,9 @@ package bahamut
 
 import (
 	"errors"
+	"sync"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
 	"go.aporeto.io/elemental"
@@ -60,7 +61,9 @@ type Publication struct {
 	Encoding     elemental.EncodingType     `msgpack:"encoding,omitempty" json:"encoding,omitempty"`
 	ResponseMode ResponseMode               `msgpack:"responseMode,omitempty" json:"responseMode,omitempty"`
 
-	replyCh chan<- *Publication
+	replyCh chan *Publication
+	replied bool
+	mux     sync.Mutex
 	span    opentracing.Span
 }
 
@@ -161,17 +164,22 @@ func (p *Publication) Duplicate() *Publication {
 // the client was not expecting a response or the supplied publication was nil. If you take
 // too long to reply to a publication an error may be returned in the errors channel you provided
 // in your call to the `Subscribe` method as the client may have given up waiting for your response.
+// Reply can only be called once for
 func (p *Publication) Reply(response *Publication) error {
+	p.mux.Lock()
+	defer p.mux.Unlock()
 
-	if p.replyCh == nil {
+	switch {
+	case p.replyCh == nil:
 		return errors.New("no response required for publication")
-	}
-
-	if response == nil {
+	case response == nil:
 		return errors.New("response cannot be nil")
+	case p.replied:
+		return errors.New("already replied to publication")
 	}
 
 	p.replyCh <- response
+	p.replied = true
 
 	return nil
 }

--- a/publication.go
+++ b/publication.go
@@ -158,13 +158,17 @@ func (p *Publication) Duplicate() *Publication {
 }
 
 // Reply will publish the provided publication back to the client. An error is returned if
-// the client was not expecting a response. If you take too long to reply to a publication
-// an error may be returned in the errors channel you provided in your call to the `Subscribe`
-// method as the client may have given up waiting for your response.
+// the client was not expecting a response or the supplied publication was nil. If you take
+// too long to reply to a publication an error may be returned in the errors channel you provided
+// in your call to the `Subscribe` method as the client may have given up waiting for your response.
 func (p *Publication) Reply(response *Publication) error {
 
 	if p.replyCh == nil {
 		return errors.New("no response required for publication")
+	}
+
+	if response == nil {
+		return errors.New("response cannot be nil")
 	}
 
 	p.replyCh <- response

--- a/pubsub_nats.go
+++ b/pubsub_nats.go
@@ -71,15 +71,7 @@ func (p *natsPubSub) Publish(publication *Publication, opts ...PubSubOptPublish)
 		opt(&config)
 	}
 
-	switch config.desiredResponse {
-	case ResponseModeACK:
-		publication.ResponseMode = ResponseModeACK
-	case ResponseModePublication:
-		publication.ResponseMode = ResponseModePublication
-	default:
-		publication.ResponseMode = ResponseModeNone
-	}
-
+	publication.ResponseMode = config.desiredResponse
 	data, err := elemental.Encode(elemental.EncodingTypeMSGPACK, publication)
 	if err != nil {
 		return fmt.Errorf("unable to encode publication. message dropped: %s", err)

--- a/pubsub_nats.go
+++ b/pubsub_nats.go
@@ -175,17 +175,6 @@ func (p *natsPubSub) Subscribe(pubs chan *Publication, errors chan error, topic 
 				replyCh := make(chan *Publication)
 				publication.replyCh = replyCh
 				go responseHandler(m.Reply, replyCh)
-			// Finally, if client has configured a custom replier using the NATSOptSubscribeReplyer, use that to generate
-			// a response.
-			default:
-				if config.replier != nil {
-					if err := p.client.Publish(m.Reply, config.replier(m)); err != nil {
-						zap.L().Error("Failed to publish custom reply. Message dropped.",
-							zap.Error(err),
-							zap.String("nats_subject", m.Reply))
-						return
-					}
-				}
 			}
 		}
 

--- a/pubsub_nats.go
+++ b/pubsub_nats.go
@@ -121,9 +121,7 @@ func (p *natsPubSub) Publish(publication *Publication, opts ...PubSubOptPublish)
 
 func (p *natsPubSub) Subscribe(pubs chan *Publication, errors chan error, topic string, opts ...PubSubOptSubscribe) func() {
 
-	config := natsSubscribeConfig{
-		replyTimeout: 5 * time.Second,
-	}
+	config := defaultSubscribeConfig()
 
 	for _, opt := range opts {
 		opt(&config)

--- a/pubsub_nats_options.go
+++ b/pubsub_nats_options.go
@@ -72,14 +72,12 @@ var ackMessage = []byte("ack")
 type natsSubscribeConfig struct {
 	queueGroup   string
 	replyTimeout time.Duration
-	replier      func(msg *nats.Msg) []byte
 }
 
 func defaultSubscribeConfig() natsSubscribeConfig {
 	return natsSubscribeConfig{
 		queueGroup:   "",
 		replyTimeout: 5 * time.Second,
-		replier:      nil,
 	}
 }
 
@@ -97,22 +95,6 @@ type natsPublishConfig struct {
 func NATSOptSubscribeQueue(queueGroup string) PubSubOptSubscribe {
 	return func(c interface{}) {
 		c.(*natsSubscribeConfig).queueGroup = queueGroup
-	}
-}
-
-// NATSOptSubscribeReplyer sets the function that will be called to eventually
-// reply to a nats Request.
-//
-// This is advanced option. You will not receive a
-// bahamut.Publication, but the raw nats.Msg received, and you must
-// reply with a direct payload []byte. If the reply cannot be sent, the subscription
-// channel will not receive anything and it is considered as a terminal error for that
-// message.
-//
-// See: https://nats.io/documentation/concepts/nats-req-rep/
-func NATSOptSubscribeReplyer(replier func(msg *nats.Msg) []byte) PubSubOptSubscribe {
-	return func(c interface{}) {
-		c.(*natsSubscribeConfig).replier = replier
 	}
 }
 

--- a/pubsub_nats_options.go
+++ b/pubsub_nats_options.go
@@ -136,9 +136,7 @@ func NATSOptRespondToChannel(ctx context.Context, resp chan *Publication) PubSub
 // NATSOptPublishRequireAck is a helper to require a ack in the limit
 // of the given context.Context. If the other side is bahamut.PubSubClient
 // using the Subscribe method, then it will automatically send back the expected
-// ack. If you are using a custom replyer with NATSOptSubscribeReplyer, you MUST
-// reply `ack` or implement your own logic to handle the reply by using
-// the option NATSOptPublishReplyValidator.
+// ack.
 //
 // This option CANNOT be combined with NATSOptRespondToChannel
 func NATSOptPublishRequireAck(ctx context.Context) PubSubOptPublish {

--- a/pubsub_nats_options.go
+++ b/pubsub_nats_options.go
@@ -70,8 +70,9 @@ func natsOptClient(client natsClient) NATSOption {
 var ackMessage = []byte("ack")
 
 type natsSubscribeConfig struct {
-	queueGroup string
-	replier    func(msg *nats.Msg) []byte
+	queueGroup   string
+	replyTimeout time.Duration
+	replier      func(msg *nats.Msg) []byte
 }
 
 type natsPublishConfig struct {
@@ -104,6 +105,14 @@ func NATSOptSubscribeQueue(queueGroup string) PubSubOptSubscribe {
 func NATSOptSubscribeReplyer(replier func(msg *nats.Msg) []byte) PubSubOptSubscribe {
 	return func(c interface{}) {
 		c.(*natsSubscribeConfig).replier = replier
+	}
+}
+
+// NATSOptSubscribeReplyTimeout sets the duration of time to wait before giving up
+// waiting for a response to publish back to the client that is expecting a response
+func NATSOptSubscribeReplyTimeout(t time.Duration) PubSubOptSubscribe {
+	return func(c interface{}) {
+		c.(*natsSubscribeConfig).replyTimeout = t
 	}
 }
 

--- a/pubsub_nats_options.go
+++ b/pubsub_nats_options.go
@@ -74,8 +74,7 @@ type natsSubscribeConfig struct {
 
 func defaultSubscribeConfig() natsSubscribeConfig {
 	return natsSubscribeConfig{
-		queueGroup:   "",
-		replyTimeout: 5 * time.Second,
+		replyTimeout: 60 * time.Second,
 	}
 }
 

--- a/pubsub_nats_options.go
+++ b/pubsub_nats_options.go
@@ -16,8 +16,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"time"
-
-	"github.com/nats-io/go-nats"
 )
 
 // A NATSOption represents an option to the pubsub backed by nats

--- a/pubsub_nats_options.go
+++ b/pubsub_nats_options.go
@@ -75,6 +75,14 @@ type natsSubscribeConfig struct {
 	replier      func(msg *nats.Msg) []byte
 }
 
+func defaultSubscribeConfig() natsSubscribeConfig {
+	return natsSubscribeConfig{
+		queueGroup:   "",
+		replyTimeout: 5 * time.Second,
+		replier:      nil,
+	}
+}
+
 type natsPublishConfig struct {
 	ctx             context.Context
 	desiredResponse ResponseMode

--- a/pubsub_nats_options_test.go
+++ b/pubsub_nats_options_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 	"time"
 
-	nats "github.com/nats-io/go-nats"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -63,11 +62,6 @@ func TestBahamut_PubSubNatsOptionsSubscribe(t *testing.T) {
 		So(c.queueGroup, ShouldEqual, "queueGroup")
 	})
 
-	Convey("Calling NATSOptSubscribeReplyer should work", t, func() {
-		r := func(msg *nats.Msg) []byte { return nil }
-		NATSOptSubscribeReplyer(r)(&c)
-		So(c.replier, ShouldEqual, r)
-	})
 }
 
 func TestBahamut_PubSubNatsOptionsPublish(t *testing.T) {

--- a/pubsub_nats_test.go
+++ b/pubsub_nats_test.go
@@ -445,39 +445,6 @@ func TestSubscribe(t *testing.T) {
 			subscribeOptions: nil,
 		},
 		{
-			description: "should be able to set a custom response using the NATSOptSubscribeReplyer option to all publications that expect a response",
-			subscribeOptions: []PubSubOptSubscribe{
-				NATSOptSubscribeReplyer(func(_ *nats.Msg) []byte {
-					return []byte("custom response message")
-				}),
-			},
-			setup: func(t *testing.T, pub *Publication) {
-
-				data, err := elemental.Encode(elemental.EncodingTypeMSGPACK, pub)
-				if err != nil {
-					t.Fatalf("test setup failed - could not encode publication - error: %+v", err)
-					return
-				}
-
-				// publish a message expecting a (custom) response
-				msg, err := nc.Request(subscribeTopic, data, threshold)
-				if err != nil {
-					t.Fatalf("test setup failed to publish/receive message - error: %+v", err)
-					return
-				}
-
-				// validate that the received response is the custom response message we specified using the NATSOptSubscribeReplyer option
-				if !bytes.Equal(msg.Data, []byte("custom response message")) {
-					t.Errorf("expected response message data to be \"%s\", but received \"%s\"", ackMessage, msg.Data)
-				}
-
-			},
-			expectedPublication: &Publication{
-				Topic: subscribeTopic,
-				Data:  []byte("message"),
-			},
-		},
-		{
 			description:      "should receive an error in errors channel if subscribing fails for any reason",
 			expectedError:    nats.ErrConnectionClosed,
 			subscribeOptions: []PubSubOptSubscribe{},

--- a/pubsub_nats_test.go
+++ b/pubsub_nats_test.go
@@ -531,7 +531,11 @@ func TestSubscribe(t *testing.T) {
 			case <-time.After(threshold):
 
 				if test.expectedPublication != nil {
-					t.Errorf("timed out expecting to receive a publication: %+v", test.expectedPublication)
+					t.Errorf("timed out expecting to receive a publication: \"%+v\"", test.expectedPublication)
+				}
+
+				if test.expectedError != nil {
+					t.Errorf("timed out expecting to receive an error: \"%+v\"", test.expectedError)
 				}
 
 			}

--- a/pubsub_nats_test.go
+++ b/pubsub_nats_test.go
@@ -418,6 +418,7 @@ func TestSubscribe(t *testing.T) {
 			description: "should respond back with an ACK message to all publications that expect an ACK response",
 			setup: func(t *testing.T, pub *Publication) {
 
+				pub.ResponseMode = ResponseModeACK
 				data, err := elemental.Encode(elemental.EncodingTypeMSGPACK, pub)
 				if err != nil {
 					t.Fatalf("test setup failed - could not encode publication - error: %+v", err)


### PR DESCRIPTION
####  ✅~This PR should be reviewed/merged **AFTER** https://github.com/aporeto-inc/bahamut/pull/59~
---

### Context

This builds on https://github.com/aporeto-inc/bahamut/pull/59 by modifying the NATS `Subscribe` implementation to consume the new `ResponseMode` attribute serialized into the `Publication` message

### High-level workflow

- Subscriber subscribes to a subject they are interested in receiving Publications for
- When Subscriber receives a Publication, it checks whether a response was even expected (_by examining the raw NATS message's `Reply` field, then it examines the `ResponseMode` attribute of the publication to determine the type of response the client is expecting:

  - **ACK response**: subscriber responds right away prior to sending the publication to the pubs channel
  - **Publication response**: a response channel is created and then a new goroutine is spawned waiting to read of this channel. The client code consuming Bahamut for subscribing would then use a new method `Reply` to respond back to the received publication. For example:

```go
	pubsCh := make(chan *bahamut.Publication)
	errsCh := make(chan error)

	disco := pubsub.Subscribe(pubsCh, errsCh, "some topic of interest", bahamut.NATSOptSubscribeQueue("main"))

	for {
		select {
		case p := <-pubsCh:
			go func(pub *bahamut.Publication) {

				// do some processing...

				// whenever you are ready, respond to the publication
				response := bahamut.NewPublication("")
				response.Data = []byte("this is my response!")
				pub.Reply(response)

			}(p)
		case err := <-errsCh:
			fmt.Printf("received an error: %+v", err)
		}
	}
```
### :boom: Breaking change(s)

- Removed the `NATSOptSubscribeReplyer` option as clients should now use the new request-reply workflow.


TODO:

- [x] get feedback
- [x] unit tests