### PR TITLE
fixes bug where client responds to a publication that has reached its reply timeout

### DIFF
--- a/publication_test.go
+++ b/publication_test.go
@@ -268,6 +268,17 @@ func TestReply(t *testing.T) {
 			response:    NewPublication("test topic"),
 			shouldError: true,
 		},
+		{
+			description: "should return an error if caller took too long to respond to publication",
+			setup: func() *Publication {
+				return &Publication{
+					replyCh:  make(chan *Publication),
+					timedOut: true,
+				}
+			},
+			response:    NewPublication("test topic"),
+			shouldError: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pubsub_nats_options_test.go
+++ b/pubsub_nats_options_test.go
@@ -62,6 +62,12 @@ func TestBahamut_PubSubNatsOptionsSubscribe(t *testing.T) {
 		So(c.queueGroup, ShouldEqual, "queueGroup")
 	})
 
+	Convey("Calling NATSOptSubscribeReplyTimeout should set the timeout", t, func() {
+		duration := 15 * time.Second
+		NATSOptSubscribeReplyTimeout(duration)(&c)
+		So(c.replyTimeout, ShouldEqual, duration)
+	})
+
 }
 
 func TestBahamut_PubSubNatsOptionsPublish(t *testing.T) {


### PR DESCRIPTION
This fixes a bug where the client's call to `Reply` can block indefinitely if the client calls `Reply` **AFTER** the response deadline has been reached.

This would happen because [the goroutine running the response handler](https://github.com/aporeto-inc/bahamut/blob/master/pubsub_nats.go#L125) would terminate [after the response deadline is hit](https://github.com/aporeto-inc/bahamut/blob/master/pubsub_nats.go#L139). As a result, when the client calls the `Reply` method, they will be [attempting to write to a channel that no longer has a receiver](https://github.com/aporeto-inc/bahamut/blob/master/publication.go#L181) and wait until the end of time 😢 