### PR TITLE
Export NATSOptClient option

### DIFF
--- a/pubsub_nats_options.go
+++ b/pubsub_nats_options.go
@@ -57,9 +57,9 @@ func NATSOptTLS(tlsConfig *tls.Config) NATSOption {
 	}
 }
 
-// natsOptClient sets the NATS client that will be used
+// NATSOptClient sets the NATS client that will be used
 // This is useful for unit testing as you can pass in a mocked NATS client
-func natsOptClient(client natsClient) NATSOption {
+func NATSOptClient(client natsClient) NATSOption {
 	return func(n *natsPubSub) {
 		n.client = client
 	}

--- a/pubsub_nats_test.go
+++ b/pubsub_nats_test.go
@@ -222,7 +222,7 @@ func TestPublish(t *testing.T) {
 			natsOptions: []NATSOption{
 				// notice how we pass a nil client explicitly to simulate the failure scenario
 				// desired by this test
-				natsOptClient(nil),
+				NATSOptClient(nil),
 			},
 		},
 		{
@@ -340,7 +340,7 @@ func TestPublish(t *testing.T) {
 
 			// note: we prepend the NATSOption client option to use our mock client just in case the
 			// test case wishes to override this option (e.g. to provide a nil client)
-			test.natsOptions = append([]NATSOption{natsOptClient(mockNATSClient)}, test.natsOptions...)
+			test.natsOptions = append([]NATSOption{NATSOptClient(mockNATSClient)}, test.natsOptions...)
 			ps := NewNATSPubSubClient(
 				natsURL,
 				test.natsOptions...,
@@ -693,7 +693,7 @@ func TestSubscribe(t *testing.T) {
 					Times(0)
 
 				return []NATSOption{
-					natsOptClient(mockClient),
+					NATSOptClient(mockClient),
 				}, callback
 			},
 			expectedPublication: nil,
@@ -711,7 +711,7 @@ func TestSubscribe(t *testing.T) {
 			}
 			// note: we prepend the NATSOption natsOptClient option to allow test cases to override the actual client being used
 			// (e.g. if they want to provide a mock client instead)
-			natOpts = append([]NATSOption{natsOptClient(nc)}, natOpts...)
+			natOpts = append([]NATSOption{NATSOptClient(nc)}, natOpts...)
 			ps := NewNATSPubSubClient(
 				fmt.Sprintf("%s:%d", serverAddr.IP, serverAddr.Port),
 				natOpts...,


### PR DESCRIPTION
This option is also useful for clients writing unit tests.