### PR TITLE
new: add option to provide strict CORS origin

### DIFF
--- a/config.go
+++ b/config.go
@@ -94,6 +94,7 @@ type config struct {
 		sessionAuthenticators []SessionAuthenticator
 		authorizers           []Authorizer
 		auditer               Auditer
+		CORSOrigin            string
 	}
 
 	rateLimiting struct {

--- a/options.go
+++ b/options.go
@@ -391,3 +391,13 @@ func OptTraceCleaner(cleaner TraceCleaner) Option {
 		c.opentracing.traceCleaner = cleaner
 	}
 }
+
+// OptCORSOrigin sets the allowed origin for CORS requests.
+// If not set, bahamut will use the HTTP Header `Origin` and if
+// it cannot find it, it will use `*`.
+// If this option is set, the given origin will always be used.
+func OptCORSOrigin(origin string) Option {
+	return func(c *config) {
+		c.security.CORSOrigin = origin
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -266,4 +266,9 @@ func TestBahamut_Options(t *testing.T) {
 		OptTraceCleaner(f)(&c)
 		So(c.opentracing.traceCleaner, ShouldEqual, f)
 	})
+
+	Convey("Calling OptCORSOrigin should work", t, func() {
+		OptCORSOrigin("here")(&c)
+		So(c.security.CORSOrigin, ShouldEqual, "here")
+	})
 }

--- a/rest_server_helpers.go
+++ b/rest_server_helpers.go
@@ -49,20 +49,26 @@ func setCommonHeader(w http.ResponseWriter, origin string, encoding elemental.En
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
 }
 
-func corsHandler(w http.ResponseWriter, r *http.Request) {
-	_, writeEncoding, _ := elemental.EncodingFromHeaders(r.Header)
-	setCommonHeader(w, r.Header.Get("Origin"), writeEncoding)
-	w.WriteHeader(http.StatusOK)
+func makeCORSHandler(origin string) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		o := r.Header.Get("Origin")
+		if origin != "" {
+			o = origin
+		}
+		_, writeEncoding, _ := elemental.EncodingFromHeaders(r.Header)
+		setCommonHeader(w, o, writeEncoding)
+		w.WriteHeader(http.StatusOK)
+	}
 }
 
-func notFoundHandler(w http.ResponseWriter, r *http.Request) {
-	_, writeEncoding, _ := elemental.EncodingFromHeaders(r.Header)
-	setCommonHeader(w, r.Header.Get("Origin"), writeEncoding)
-	writeHTTPResponse(w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), ErrNotFound))
+func makeNotFoundHandler(origin string) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		writeHTTPResponse(origin, w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), ErrNotFound))
+	}
 }
 
 // writeHTTPResponse writes the response into the given http.ResponseWriter.
-func writeHTTPResponse(w http.ResponseWriter, r *elemental.Response) int {
+func writeHTTPResponse(CORSOrigin string, w http.ResponseWriter, r *elemental.Response) int {
 
 	// If r is nil, we simply stop.
 	// It mostly means the client closed the connection and
@@ -71,7 +77,12 @@ func writeHTTPResponse(w http.ResponseWriter, r *elemental.Response) int {
 		return 0
 	}
 
-	setCommonHeader(w, r.Request.Headers.Get("Origin"), r.Request.Accept)
+	origin := r.Request.Headers.Get("Origin")
+	if CORSOrigin != "" {
+		origin = CORSOrigin
+	}
+
+	setCommonHeader(w, origin, r.Request.Accept)
 
 	if r.Redirect != "" {
 		w.Header().Set("Location", r.Redirect)

--- a/rest_server_helpers_test.go
+++ b/rest_server_helpers_test.go
@@ -67,7 +67,7 @@ func TestRestServerHelper_corsHandler(t *testing.T) {
 		h.Add("Origin", "toto")
 
 		w := httptest.NewRecorder()
-		corsHandler(w, &http.Request{Header: h, URL: &url.URL{Path: "/path"}})
+		makeCORSHandler("")(w, &http.Request{Header: h, URL: &url.URL{Path: "/path"}})
 
 		Convey("Then the response should be correct", func() {
 			So(w.Code, ShouldEqual, http.StatusOK)
@@ -83,7 +83,7 @@ func TestRestServerHelper_notFoundHandler(t *testing.T) {
 		h.Add("Origin", "toto")
 
 		w := httptest.NewRecorder()
-		notFoundHandler(w, &http.Request{Header: h, URL: &url.URL{Path: "/path"}})
+		makeNotFoundHandler("")(w, &http.Request{Header: h, URL: &url.URL{Path: "/path"}})
 
 		Convey("Then the response should be correct", func() {
 			So(w.Code, ShouldEqual, http.StatusNotFound)
@@ -99,7 +99,7 @@ func TestRestServerHelper_writeHTTPResponse(t *testing.T) {
 
 		Convey("When I call writeHTTPResponse", func() {
 
-			code := writeHTTPResponse(w, nil)
+			code := writeHTTPResponse("", w, nil)
 
 			Convey("Then the code should be 0", func() {
 				So(code, ShouldEqual, 0)
@@ -115,10 +115,30 @@ func TestRestServerHelper_writeHTTPResponse(t *testing.T) {
 
 		Convey("When I call writeHTTPResponse", func() {
 
-			code := writeHTTPResponse(w, r)
+			code := writeHTTPResponse("", w, r)
 
 			Convey("Then the should header Location should be set", func() {
 				So(w.Header().Get("location"), ShouldEqual, "https://la.bas")
+			})
+
+			Convey("Then the code should be 302", func() {
+				So(code, ShouldEqual, 302)
+			})
+		})
+	})
+
+	Convey("Given I have a CORS origin configured", t, func() {
+
+		w := httptest.NewRecorder()
+		r := elemental.NewResponse(elemental.NewRequest())
+		r.Redirect = "https://la.bas"
+
+		Convey("When I call writeHTTPResponse", func() {
+
+			code := writeHTTPResponse("ici", w, r)
+
+			Convey("Then the should header Location should be set", func() {
+				So(w.Header().Get("Access-Control-Allow-Origin"), ShouldEqual, "ici")
 			})
 
 			Convey("Then the code should be 302", func() {
@@ -136,7 +156,7 @@ func TestRestServerHelper_writeHTTPResponse(t *testing.T) {
 
 		Convey("When I call writeHTTPResponse", func() {
 
-			code := writeHTTPResponse(w, r)
+			code := writeHTTPResponse("", w, r)
 
 			Convey("Then the should headers should be correct", func() {
 				So(w.Header().Get("X-Count-Total"), ShouldEqual, "0")
@@ -163,7 +183,7 @@ func TestRestServerHelper_writeHTTPResponse(t *testing.T) {
 
 		Convey("When I call writeHTTPResponse", func() {
 
-			code := writeHTTPResponse(w, r)
+			code := writeHTTPResponse("", w, r)
 
 			Convey("Then the should header message should be set", func() {
 				So(w.Header().Get("X-Messages"), ShouldEqual, "msg1;msg2")
@@ -185,7 +205,7 @@ func TestRestServerHelper_writeHTTPResponse(t *testing.T) {
 
 		Convey("When I call writeHTTPResponse", func() {
 
-			code := writeHTTPResponse(w, r)
+			code := writeHTTPResponse("", w, r)
 
 			Convey("Then the body should be correct", func() {
 				So(w.Header().Get("X-Count-Total"), ShouldEqual, "0")

--- a/websocket_server.go
+++ b/websocket_server.go
@@ -193,7 +193,7 @@ func (n *pushServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 
 	readEncodingType, writeEncodingType, err := elemental.EncodingFromHeaders(r.Header)
 	if err != nil {
-		writeHTTPResponse(w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err))
+		writeHTTPResponse(n.cfg.security.CORSOrigin, w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err))
 	}
 
 	session := newWSPushSession(r, n.cfg, n.unregisterSession, readEncodingType, writeEncodingType)
@@ -210,24 +210,24 @@ func (n *pushServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 	session.setRemoteAddress(clientIP)
 
 	if err := n.authSession(session); err != nil {
-		writeHTTPResponse(w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err))
+		writeHTTPResponse(n.cfg.security.CORSOrigin, w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err))
 		return
 	}
 
 	if err := n.initPushSession(session); err != nil {
-		writeHTTPResponse(w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err))
+		writeHTTPResponse(n.cfg.security.CORSOrigin, w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err))
 		return
 	}
 
 	ws, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		writeHTTPResponse(w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err))
+		writeHTTPResponse(n.cfg.security.CORSOrigin, w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err))
 		return
 	}
 
 	conn, err := wsc.Accept(r.Context(), ws, wsc.Config{WriteChanSize: 1024, ReadChanSize: 512})
 	if err != nil {
-		writeHTTPResponse(w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err))
+		writeHTTPResponse(n.cfg.security.CORSOrigin, w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err))
 		return
 	}
 


### PR DESCRIPTION
bahamut uses the HTTP Header `Origin` to set the CORS allowed origin. If it finds no header, it uses `*`.

This patch adds an option `OptCORSOrigin(string)` that allows to force using the given strict as CORS allowed origin