### PR TITLE
new: support for custom marshallers

### DIFF
--- a/bahamut.go
+++ b/bahamut.go
@@ -26,6 +26,9 @@ import (
 // CustomUmarshaller is the type of function use to create custom unmarshalling.
 type CustomUmarshaller func(*elemental.Request) (elemental.Identifiable, error)
 
+// CustomMarshaller is the type of function use to create custom marshalling.
+type CustomMarshaller func(data interface{}) ([]byte, error)
+
 // RegisterProcessorOrDie will register the given Processor for the given
 // Identity and will exit in case of errors. This is just a helper for
 // Server.RegisterProcessor function.

--- a/config.go
+++ b/config.go
@@ -106,6 +106,7 @@ type config struct {
 		readOnly                   bool
 		readOnlyExcludedIdentities []elemental.Identity
 		unmarshallers              map[elemental.Identity]CustomUmarshaller
+		marshallers                map[elemental.Identity]CustomMarshaller
 	}
 
 	meta struct {

--- a/options.go
+++ b/options.go
@@ -331,6 +331,18 @@ func OptUnmarshallers(unmarshallers map[elemental.Identity]CustomUmarshaller) Op
 	}
 }
 
+// OptMarshallers sets the custom marshallers.
+//
+// Marshallers contains a list of custom marshaller per identity.
+// This allows to create custom function to marshal the payload of a response.
+// If none is provided for a particular identity, the standard unmarshal function
+// is used.
+func OptMarshallers(marshallers map[elemental.Identity]CustomMarshaller) Option {
+	return func(c *config) {
+		c.model.marshallers = marshallers
+	}
+}
+
 // OptServiceInfo configures the service basic information.
 //
 // ServiceName contains the name of the service.

--- a/options_test.go
+++ b/options_test.go
@@ -223,6 +223,12 @@ func TestBahamut_Options(t *testing.T) {
 		So(c.model.unmarshallers, ShouldResemble, u)
 	})
 
+	Convey("Calling OptMarshallers should work", t, func() {
+		u := map[elemental.Identity]CustomMarshaller{testmodel.ListIdentity: func(interface{}) ([]byte, error) { return nil, nil }}
+		OptMarshallers(u)(&c)
+		So(c.model.marshallers, ShouldResemble, u)
+	})
+
 	Convey("Calling OptServiceInfo should work", t, func() {
 		sb := map[string]interface{}{}
 		OptServiceInfo("n", "v", sb)(&c)

--- a/rest_server.go
+++ b/rest_server.go
@@ -242,7 +242,7 @@ func (a *restServer) makeHandler(handler handlerFunc) http.HandlerFunc {
 
 		request, err := elemental.NewRequestFromHTTPRequest(req, a.cfg.model.modelManagers[0])
 		if err != nil {
-			code := writeHTTPResponse(a.cfg.security.CORSOrigin, w, makeErrorResponse(req.Context(), elemental.NewResponse(elemental.NewRequest()), err))
+			code := writeHTTPResponse(a.cfg.security.CORSOrigin, w, makeErrorResponse(req.Context(), elemental.NewResponse(elemental.NewRequest()), err, nil))
 			if measure != nil {
 				measure(code, nil)
 			}
@@ -256,7 +256,7 @@ func (a *restServer) makeHandler(handler handlerFunc) http.HandlerFunc {
 			rctx, cancel := context.WithTimeout(req.Context(), 1*time.Second)
 			defer cancel()
 			if err = a.cfg.rateLimiting.rateLimiter.Wait(rctx); err != nil {
-				code := writeHTTPResponse(a.cfg.security.CORSOrigin, w, makeErrorResponse(ctx, elemental.NewResponse(request), ErrRateLimit))
+				code := writeHTTPResponse(a.cfg.security.CORSOrigin, w, makeErrorResponse(ctx, elemental.NewResponse(request), ErrRateLimit, nil))
 				if measure != nil {
 					measure(code, opentracing.SpanFromContext(ctx))
 				}

--- a/rest_server_helpers.go
+++ b/rest_server_helpers.go
@@ -63,7 +63,7 @@ func makeCORSHandler(origin string) func(w http.ResponseWriter, r *http.Request)
 
 func makeNotFoundHandler(origin string) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		writeHTTPResponse(origin, w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), ErrNotFound))
+		writeHTTPResponse(origin, w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), ErrNotFound, nil))
 	}
 }
 

--- a/websocket_server.go
+++ b/websocket_server.go
@@ -193,7 +193,7 @@ func (n *pushServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 
 	readEncodingType, writeEncodingType, err := elemental.EncodingFromHeaders(r.Header)
 	if err != nil {
-		writeHTTPResponse(n.cfg.security.CORSOrigin, w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err))
+		writeHTTPResponse(n.cfg.security.CORSOrigin, w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err, nil))
 	}
 
 	session := newWSPushSession(r, n.cfg, n.unregisterSession, readEncodingType, writeEncodingType)
@@ -210,24 +210,24 @@ func (n *pushServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 	session.setRemoteAddress(clientIP)
 
 	if err := n.authSession(session); err != nil {
-		writeHTTPResponse(n.cfg.security.CORSOrigin, w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err))
+		writeHTTPResponse(n.cfg.security.CORSOrigin, w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err, nil))
 		return
 	}
 
 	if err := n.initPushSession(session); err != nil {
-		writeHTTPResponse(n.cfg.security.CORSOrigin, w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err))
+		writeHTTPResponse(n.cfg.security.CORSOrigin, w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err, nil))
 		return
 	}
 
 	ws, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		writeHTTPResponse(n.cfg.security.CORSOrigin, w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err))
+		writeHTTPResponse(n.cfg.security.CORSOrigin, w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err, nil))
 		return
 	}
 
 	conn, err := wsc.Accept(r.Context(), ws, wsc.Config{WriteChanSize: 1024, ReadChanSize: 512})
 	if err != nil {
-		writeHTTPResponse(n.cfg.security.CORSOrigin, w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err))
+		writeHTTPResponse(n.cfg.security.CORSOrigin, w, makeErrorResponse(r.Context(), elemental.NewResponse(elemental.NewRequest()), err, nil))
 		return
 	}
 


### PR DESCRIPTION
adds the option `OptMarshallers(marshallers map[elemental.Identity]CustomMarshaller) ` to pass a list of custom marshalers that will be used to encode the response using a custom marshaling process