### PR TITLE
Add support for fine-grained websocket filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ vendor
 *.cov
 .idea/*
 artifacts
+remod.dev
+.remod

--- a/authorizer/mtls/authorizer_test.go
+++ b/authorizer/mtls/authorizer_test.go
@@ -943,6 +943,7 @@ type mockSession struct {
 func (s *mockSession) Identifier() string                       { return "" }
 func (s *mockSession) Parameter(string) string                  { return "" }
 func (s *mockSession) Header(string) string                     { return "" }
+func (s *mockSession) PushConfig() *elemental.PushConfig        { return nil }
 func (s *mockSession) SetClaims(c []string)                     { s.claims = c }
 func (s *mockSession) Claims() []string                         { return s.claims }
 func (s *mockSession) ClaimsMap() map[string]string             { return nil }

--- a/interfaces.go
+++ b/interfaces.go
@@ -248,9 +248,9 @@ type PushDispatchHandler interface {
 	RelatedEventIdentities(string) []string
 
 	// SummarizeEvent is called once per event and allows the implementation
-	// to return am intenface that will be passed to ShouldDispatch.
+	// to return an interface that will be passed to ShouldDispatch.
 	// If you need to decode an event to read some information to make a
-	// dispatch decision, this is a good place as it will allow to only
+	// dispatch decision, this is a good place as it will allow you to only
 	// do this once.
 	SummarizeEvent(event *elemental.Event) (interface{}, error)
 }
@@ -278,6 +278,7 @@ type Session interface {
 	Identifier() string
 	Parameter(string) string
 	Header(string) string
+	PushConfig() *elemental.PushConfig
 	SetClaims([]string)
 	Claims() []string
 	ClaimsMap() map[string]string

--- a/interfaces.go
+++ b/interfaces.go
@@ -255,6 +255,14 @@ type PushDispatchHandler interface {
 	SummarizeEvent(event *elemental.Event) (interface{}, error)
 }
 
+// CloserNotifierError is an error type that can optionally be returned by the callback, ShouldDispatch(PushSession, *elemental.Event, interface{}),
+// defined in the PushDispatchHandler interface. If the callback returns an error that satisfies the CloserNotifierError,
+// bahamut will call the `ShouldCloseSocket()` to determine whether the socket connection should be closed. Useful in situations where
+// it makes no sense keeping the socket alive anymore (e.g. client sent a push config that contains an unsupported filter comparator)
+type CloserNotifierError interface {
+	ShouldCloseSocket() (bool, int)
+}
+
 // PushPublishHandler is the interface that must be implemented in order to
 // to be used as the Bahamut Push Publish handler.
 type PushPublishHandler interface {

--- a/websocket_push_session_test.go
+++ b/websocket_push_session_test.go
@@ -97,7 +97,7 @@ func TestWSPushSession_DirectPush(t *testing.T) {
 			f := elemental.NewPushConfig()
 			f.FilterIdentity("not-list")
 
-			s.setCurrentFilter(f)
+			s.setCurrentPushConfig(f)
 			go s.DirectPush(evt)
 
 			var data []byte
@@ -209,20 +209,20 @@ func TestWSPushSession_String(t *testing.T) {
 
 func TestWSPushSession_Filtering(t *testing.T) {
 
-	Convey("Given I call setCurrentFilter", t, func() {
+	Convey("Given I call setCurrentPushConfig", t, func() {
 
 		req, _ := http.NewRequest("GET", "bla", nil)
 		cfg := config{}
 		s := newWSPushSession(req, cfg, nil, elemental.EncodingTypeMSGPACK, elemental.EncodingTypeMSGPACK)
 
-		f := elemental.NewPushConfig()
-		f.SetParameter("hello", "world")
+		pc := elemental.NewPushConfig()
+		pc.SetParameter("hello", "world")
 
-		s.setCurrentFilter(f)
+		s.setCurrentPushConfig(pc)
 
 		Convey("Then the filter should be installed", func() {
-			So(s.currentFilter(), ShouldNotEqual, f)
-			So(s.currentFilter(), ShouldResemble, f)
+			So(s.currentPushConfig(), ShouldNotEqual, pc)
+			So(s.currentPushConfig(), ShouldResemble, pc)
 		})
 
 		Convey("Then the parameters have benn installed", func() {
@@ -231,10 +231,10 @@ func TestWSPushSession_Filtering(t *testing.T) {
 
 		Convey("When I reset the filter to nil", func() {
 
-			s.setCurrentFilter(nil)
+			s.setCurrentPushConfig(nil)
 
 			Convey("Then the filter should be uninstalled", func() {
-				So(s.currentFilter(), ShouldBeNil)
+				So(s.currentPushConfig(), ShouldBeNil)
 			})
 		})
 	})
@@ -408,7 +408,7 @@ func TestWSPushSession_listen(t *testing.T) {
 
 			f := elemental.NewPushConfig()
 			f.FilterIdentity("not-list")
-			s.setCurrentFilter(f)
+			s.setCurrentPushConfig(f)
 
 			s.DirectPush(testEvent)
 
@@ -470,7 +470,7 @@ func TestWSPushSession_listen(t *testing.T) {
 			<-time.After(300 * time.Millisecond)
 
 			Convey("Then the filter should be correctly set", func() {
-				So(s.currentFilter().String(), ShouldEqual, `<pushconfig identities:map[not-list:[]] identityfilters:map[]>`)
+				So(s.currentPushConfig().String(), ShouldEqual, `<pushconfig identities:map[not-list:[]] identityfilters:map[]>`)
 			})
 		})
 
@@ -488,7 +488,7 @@ func TestWSPushSession_listen(t *testing.T) {
 			}
 
 			Convey("Then the filter should be nil", func() {
-				So(s.currentFilter(), ShouldBeNil)
+				So(s.currentPushConfig(), ShouldBeNil)
 				So(doneErr, ShouldNotBeNil)
 				So(doneErr.Error(), ShouldEqual, "1003")
 			})

--- a/websocket_server.go
+++ b/websocket_server.go
@@ -349,11 +349,11 @@ func (n *pushServer) start(ctx context.Context) {
 					if n.cfg.pushServer.dispatchHandler != nil {
 						dispatch, err := n.cfg.pushServer.dispatchHandler.ShouldDispatch(session, event, eventSummary)
 						if err != nil {
-							//if 'ShouldDispatch' returns an error type that has the method 'ShouldCloseSocket() (bool, int)'
-							//then it can inform whether the socket should be closed along with a code to use in the
-							//close message. This is useful in cases where it makes no sense to continue serving the client
-							//(e.g. the client configured a semantically invalid push config, for example: they used a comparator
-							//that is not yet supported/implemented).
+							// if 'ShouldDispatch' returns an error type that has the method 'ShouldCloseSocket() (bool, int)'
+							// then it can inform whether the socket should be closed along with a code to use in the
+							// close message. This is useful in cases where it makes no sense to continue serving the client
+							// (e.g. the client configured a semantically invalid push config, for example: they used a comparator
+							// that is not yet supported/implemented).
 							if closer, ok := err.(interface {
 								ShouldCloseSocket() (bool, int)
 							}); ok {

--- a/websocket_server.go
+++ b/websocket_server.go
@@ -349,14 +349,12 @@ func (n *pushServer) start(ctx context.Context) {
 					if n.cfg.pushServer.dispatchHandler != nil {
 						dispatch, err := n.cfg.pushServer.dispatchHandler.ShouldDispatch(session, event, eventSummary)
 						if err != nil {
-							// if 'ShouldDispatch' returns an error type that has the method 'ShouldCloseSocket() (bool, int)'
+							// if 'ShouldDispatch' returns an error type that satisfies the 'CloserNotifierError' interface
 							// then it can inform whether the socket should be closed along with a code to use in the
 							// close message. This is useful in cases where it makes no sense to continue serving the client
-							// (e.g. the client configured a semantically invalid push config, for example: they used a comparator
+							// (e.g. the client configured a semantically invalid push config by using a comparator
 							// that is not yet supported/implemented).
-							if closer, ok := err.(interface {
-								ShouldCloseSocket() (bool, int)
-							}); ok {
+							if closer, ok := err.(CloserNotifierError); ok {
 								if close, code := closer.ShouldCloseSocket(); close {
 									session.close(code)
 									session.unregister(session)

--- a/websocket_server.go
+++ b/websocket_server.go
@@ -326,7 +326,7 @@ func (n *pushServer) start(ctx context.Context) {
 
 					// If the event identity (or related identities) are filtered out
 					// we don't send it.
-					if f := session.currentFilter(); f != nil {
+					if f := session.currentPushConfig(); f != nil {
 
 						identities := []string{event.Identity}
 						if n.cfg.pushServer.dispatchHandler != nil {

--- a/websocket_server_test.go
+++ b/websocket_server_test.go
@@ -521,6 +521,23 @@ func TestWebsocketServer_pushEvents(t *testing.T) {
 	})
 }
 
+// notifierError is an error type that satisfies bahamut.CloserNotifierError interface which can be returned from a dispatch
+// handler 'ShouldDispatch' callback in a push server. This allows the callback to make a decision with respect to whether
+// the session should be closed (along with the close code)
+type notifierError struct {
+	err         error
+	shouldClose bool
+	code        int
+}
+
+func (ne *notifierError) Error() string {
+	return ne.err.Error()
+}
+
+func (ne *notifierError) ShouldCloseSocket() (bool, int) {
+	return ne.shouldClose, ne.code
+}
+
 func TestWebsocketServer_start(t *testing.T) {
 
 	pf := func(identity elemental.Identity) (Processor, error) {
@@ -796,6 +813,102 @@ func TestWebsocketServer_start(t *testing.T) {
 		So(msg1, ShouldBeNil)
 		So(msg2, ShouldBeNil)
 		l.Unlock()
+	})
+
+	Convey("Given the callback 'ShouldDispatch' returns an error indicating the socket should be closed, then no event should be dispatched and the sessions are unregistered", t, func() {
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		pushServer, pushHandler, sessionA, sessionB := makePubsub(ctx, "")
+		connectionA, connectionB := sessionA.conn.(wsc.MockWebsocket), sessionB.conn.(wsc.MockWebsocket)
+
+		// notice how we are making the should dispatch callback return an error that satisfies the 'CloserNotifierError' interface
+		// in this case, we make the error indicate that it should close the socket along with a custom close code
+		pushHandler.shouldDispatchOK = false
+		pushHandler.shouldDispatchErr = &notifierError{
+			err:         fmt.Errorf("oops, some error occurred"),
+			shouldClose: true,
+			code:        4001,
+		}
+
+		event := elemental.NewEvent(elemental.EventCreate, testmodel.NewList())
+		publication := NewPublication("")
+		if err := publication.Encode(event); err != nil {
+			panic(fmt.Errorf("test setup failed - error encoding publication: %v", err))
+		}
+
+		pushServer.publications <- publication
+
+		var dataA, dataB []byte
+		ready := make(chan struct{})
+		go func() {
+			defer close(ready)
+			for {
+				select {
+				case dataA = <-connectionA.LastWrite():
+				case dataB = <-connectionB.LastWrite():
+				case <-time.After(1 * time.Second):
+					return
+				}
+			}
+		}()
+		<-ready
+
+		// nothing should have been dispatched
+		So(dataA, ShouldBeNil)
+		So(dataB, ShouldBeNil)
+
+		// both sessions should have been unregistered
+		So(pushServer.sessions, ShouldBeEmpty)
+	})
+
+	Convey("Given the callback 'ShouldDispatch' returns an error indicating the socket should NOT BE closed, then no event should be dispatched and the sessions should still be present", t, func() {
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		pushServer, pushHandler, sessionA, sessionB := makePubsub(ctx, "")
+		connectionA, connectionB := sessionA.conn.(wsc.MockWebsocket), sessionB.conn.(wsc.MockWebsocket)
+
+		// notice how we are making the should dispatch callback return an error that satisfies the 'CloserNotifierError' interface
+		pushHandler.shouldDispatchOK = false
+		pushHandler.shouldDispatchErr = &notifierError{
+			err: fmt.Errorf("oops, some error occurred"),
+			// notice how we are NOT closing the socket here - this is the main difference between this test and the one above
+			shouldClose: false,
+			code:        4001,
+		}
+
+		event := elemental.NewEvent(elemental.EventCreate, testmodel.NewList())
+		publication := NewPublication("")
+		if err := publication.Encode(event); err != nil {
+			panic(fmt.Errorf("test setup failed - error encoding publication: %v", err))
+		}
+
+		pushServer.publications <- publication
+
+		var dataA, dataB []byte
+		ready := make(chan struct{})
+		go func() {
+			defer close(ready)
+			for {
+				select {
+				case dataA = <-connectionA.LastWrite():
+				case dataB = <-connectionB.LastWrite():
+				case <-time.After(1 * time.Second):
+					return
+				}
+			}
+		}()
+		<-ready
+
+		// nothing should have been dispatched because an error was returned by the callback
+		So(dataA, ShouldBeNil)
+		So(dataB, ShouldBeNil)
+
+		// both sessions should still be present because the callback error said NOT to close the socket
+		So(pushServer.sessions, ShouldHaveLength, 2)
 	})
 
 	Convey("Given I push an event that is that older than session connection time", t, func() {

--- a/websocket_server_test.go
+++ b/websocket_server_test.go
@@ -591,11 +591,11 @@ func TestWebsocketServer_start(t *testing.T) {
 
 		filter := elemental.NewPushConfig()
 		filter.FilterIdentity("something-else")
-		s1.setCurrentFilter(filter)
+		s1.setCurrentPushConfig(filter)
 
 		filter = elemental.NewPushConfig()
 		filter.FilterIdentity("list")
-		s2.setCurrentFilter(filter)
+		s2.setCurrentPushConfig(filter)
 
 		pushHandler.shouldDispatchOK = true
 
@@ -649,7 +649,7 @@ func TestWebsocketServer_start(t *testing.T) {
 
 		filter := elemental.NewPushConfig()
 		filter.FilterIdentity("something-else")
-		s1.setCurrentFilter(filter)
+		s1.setCurrentPushConfig(filter)
 
 		pushHandler.shouldDispatchOK = true
 


### PR DESCRIPTION
### Issue: https://github.com/aporeto-inc/aporeto/issues/1699
#### ℹ️ This PR is building on-top of API changes to elemental introduced here: https://github.com/aporeto-inc/elemental/pull/61
----

### This PR:

- ⚠️ **Breaking change**: add new method to the `Session` interface, `PushConfig`, to make it possible to retrieve the push config currently active on the session.

Note: this was done so that [this callback](https://github.com/aporeto-inc/bahamut/blob/69c31e07899a7719b33888c903b15ef507a7ac62/interfaces.go#L243):

1.  has enough context to decide whether it is worth parsing the entire identifiable
2. be able to do fine-grain identity filtering via https://github.com/aporeto-inc/elemental/blob/master/matcher.go#L10



- :fire: Remove usage of deprecated type `elemental.PushFilter`; replaced with the re-named equivalent `elemental.PushConfig`

- Parse the identity filters upon receipt of a `elemental.PushConfig` to avoid having to parse them on each push event received by the push server
    - in the event that parsing fails, the socket is closed.

### TODO:

- [x] test for new error handling functionality when calling `ShouldDispatch`
- [x] test for verifying parsing logic on receipt of an `elemental.PushConfig` from connected client
    - [x] happy path
    - [x] error case where the parsing fails - socket should get closed

