### PR TITLE
new: support for custom response writer

### DIFF
--- a/context.go
+++ b/context.go
@@ -21,23 +21,24 @@ import (
 )
 
 type bcontext struct {
-	claims        []string
-	claimsMap     map[string]string
-	count         int
-	ctx           context.Context
-	events        elemental.Events
-	eventsLock    *sync.Mutex
-	id            string
-	inputData     interface{}
-	messages      []string
-	messagesLock  *sync.Mutex
-	metadata      map[interface{}]interface{}
-	outputData    interface{}
-	redirect      string
-	request       *elemental.Request
-	statusCode    int
-	next          string
-	outputCookies []*http.Cookie
+	claims         []string
+	claimsMap      map[string]string
+	count          int
+	ctx            context.Context
+	events         elemental.Events
+	eventsLock     *sync.Mutex
+	id             string
+	inputData      interface{}
+	messages       []string
+	messagesLock   *sync.Mutex
+	metadata       map[interface{}]interface{}
+	next           string
+	outputCookies  []*http.Cookie
+	outputData     interface{}
+	redirect       string
+	request        *elemental.Request
+	responseWriter ResponseWriter
+	statusCode     int
 }
 
 // NewContext creates a new *Context.
@@ -95,7 +96,21 @@ func (c *bcontext) OutputData() interface{} {
 }
 
 func (c *bcontext) SetOutputData(data interface{}) {
+
+	if c.responseWriter != nil {
+		panic("you cannot use SetOutputData after using SetResponseWriter")
+	}
+
 	c.outputData = data
+}
+
+func (c *bcontext) SetResponseWriter(writer ResponseWriter) {
+
+	if c.outputData != nil {
+		panic("you cannot use SetResponseWriter after using SetOutputData")
+	}
+
+	c.responseWriter = writer
 }
 
 func (c *bcontext) StatusCode() int {
@@ -193,6 +208,7 @@ func (c *bcontext) Duplicate() Context {
 	c2.messages = append(c2.messages, c.messages...)
 	c2.next = c.next
 	c2.outputCookies = append(c2.outputCookies, c.outputCookies...)
+	c2.responseWriter = c.responseWriter
 
 	for k, v := range c.claimsMap {
 		c2.claimsMap[k] = v

--- a/gateway/options.go
+++ b/gateway/options.go
@@ -45,6 +45,11 @@ const (
 	// the HTTP response writer.
 	InterceptorActionForwardWS
 
+	// InterceptorActionForwardDirect means the Gateway will continue forwarding the request directly.
+	// In that case the Interceptor must only modify the request, and MUST NOT use
+	// the HTTP response writer.
+	InterceptorActionForwardDirect
+
 	// InterceptorActionStop means the interceptor handled the request
 	// and the gateway will not do anything more.
 	InterceptorActionStop
@@ -63,6 +68,7 @@ type gwconfig struct {
 	maintenance                 bool
 	metricsManager              bahamut.MetricsManager
 	prefixInterceptors          map[string]InterceptorFunc
+	suffixInterceptors          map[string]InterceptorFunc
 	proxyProtocolEnabled        bool
 	proxyProtocolSubnet         string
 	rateLimitingBurst           int64
@@ -89,6 +95,7 @@ func newGatewayConfig() *gwconfig {
 	return &gwconfig{
 		corsOrigin:                  "*",
 		prefixInterceptors:          map[string]InterceptorFunc{},
+		suffixInterceptors:          map[string]InterceptorFunc{},
 		exactInterceptors:           map[string]InterceptorFunc{},
 		tcpRateLimitingBurst:        100,
 		tcpRateLimitingCPS:          200.0,
@@ -209,6 +216,13 @@ func OptionMetricsManager(metricsManager bahamut.MetricsManager) Option {
 func OptionRegisterPrefixInterceptor(prefix string, f InterceptorFunc) Option {
 	return func(cfg *gwconfig) {
 		cfg.prefixInterceptors[prefix] = f
+	}
+}
+
+// OptionRegisterSuffixInterceptor registers a given InterceptorFunc for the given path suffix.
+func OptionRegisterSuffixInterceptor(prefix string, f InterceptorFunc) Option {
+	return func(cfg *gwconfig) {
+		cfg.suffixInterceptors[prefix] = f
 	}
 }
 

--- a/gateway/options_test.go
+++ b/gateway/options_test.go
@@ -82,6 +82,14 @@ func Test_Options(t *testing.T) {
 		So(c.prefixInterceptors["/prefix"], ShouldEqual, f)
 	})
 
+	Convey("Calling OptionRegisterSuffixInterceptor should work", t, func() {
+		f := func(http.ResponseWriter, *http.Request, ErrorWriter) (InterceptorAction, string, error) {
+			return InterceptorActionForward, "", nil
+		}
+		OptionRegisterSuffixInterceptor("/suffix", f)(c)
+		So(c.suffixInterceptors["/suffix"], ShouldEqual, f)
+	})
+
 	Convey("Calling OptionRegisterExactInterceptor should work", t, func() {
 		f := func(http.ResponseWriter, *http.Request, ErrorWriter) (InterceptorAction, string, error) {
 			return InterceptorActionForward, "", nil

--- a/interfaces.go
+++ b/interfaces.go
@@ -80,6 +80,12 @@ type Server interface {
 	Run(context.Context)
 }
 
+// A ResponseWriter is a function you can use in
+// the Context to handle the writing of the response by
+// yourself. You are responsible for the full handling of the response,
+// including encoding, setting the CORS headers etc.
+type ResponseWriter func(w http.ResponseWriter) int
+
 // A Context contains all information about a current operation.
 type Context interface {
 
@@ -102,7 +108,21 @@ type Context interface {
 	OutputData() interface{}
 
 	// SetOutputData sets the data that will be returned to the client.
+	//
+	// If you use SetOutputData after having already used SetResponseWriter,
+	// the call will panic.
 	SetOutputData(interface{})
+
+	// SetResponseWriter sets the ResponseWriter function to use to write the response back to the client.
+	//
+	// No additional operation or check will be performed by Bahamut. You are responsible
+	// for correctly encoding the response, setting the header etc. This is useful when
+	// you want to handle a route that is note really fitting in the handling of an elemental Model
+	// like for instance handling file download, response streaming etc.
+	//
+	// If you use SetResponseWriter after having already used SetOutputData,
+	// the call will panic.
+	SetResponseWriter(ResponseWriter)
 
 	// Set count sets the count.
 	SetCount(int)

--- a/rest_server.go
+++ b/rest_server.go
@@ -285,7 +285,17 @@ func (a *restServer) makeHandler(handler handlerFunc) http.HandlerFunc {
 			}
 		}
 
-		code := writeHTTPResponse(a.cfg.security.CORSOrigin, w, handler(newContext(ctx, request), a.cfg, a.processorFinder, a.pusher))
+		bctx := newContext(ctx, request)
+		resp := handler(bctx, a.cfg, a.processorFinder, a.pusher)
+		var code int
+
+		switch {
+		case bctx.responseWriter != nil:
+			code = bctx.responseWriter(w)
+		default:
+			code = writeHTTPResponse(a.cfg.security.CORSOrigin, w, resp)
+		}
+
 		if measure != nil {
 			measure(code, opentracing.SpanFromContext(ctx))
 		}


### PR DESCRIPTION

Setting a custom ResponseWriter in the bahamut.Context let the user write the raw http response to the client using the standard http.ResponseWritter.