### PR TITLE
new: support for disabling auto pushing

### DIFF
--- a/context.go
+++ b/context.go
@@ -21,24 +21,25 @@ import (
 )
 
 type bcontext struct {
-	claims         []string
-	claimsMap      map[string]string
-	count          int
-	ctx            context.Context
-	events         elemental.Events
-	eventsLock     *sync.Mutex
-	id             string
-	inputData      interface{}
-	messages       []string
-	messagesLock   *sync.Mutex
-	metadata       map[interface{}]interface{}
-	next           string
-	outputCookies  []*http.Cookie
-	outputData     interface{}
-	redirect       string
-	request        *elemental.Request
-	responseWriter ResponseWriter
-	statusCode     int
+	claims                []string
+	claimsMap             map[string]string
+	count                 int
+	ctx                   context.Context
+	events                elemental.Events
+	eventsLock            *sync.Mutex
+	id                    string
+	inputData             interface{}
+	messages              []string
+	messagesLock          *sync.Mutex
+	metadata              map[interface{}]interface{}
+	next                  string
+	outputCookies         []*http.Cookie
+	outputData            interface{}
+	redirect              string
+	request               *elemental.Request
+	responseWriter        ResponseWriter
+	statusCode            int
+	disableOutputDataPush bool
 }
 
 // NewContext creates a new *Context.
@@ -93,6 +94,10 @@ func (c *bcontext) SetInputData(data interface{}) {
 
 func (c *bcontext) OutputData() interface{} {
 	return c.outputData
+}
+
+func (c *bcontext) SetDisableOutputDataPush(disabled bool) {
+	c.disableOutputDataPush = disabled
 }
 
 func (c *bcontext) SetOutputData(data interface{}) {
@@ -209,6 +214,7 @@ func (c *bcontext) Duplicate() Context {
 	c2.next = c.next
 	c2.outputCookies = append(c2.outputCookies, c.outputCookies...)
 	c2.responseWriter = c.responseWriter
+	c2.disableOutputDataPush = c.disableOutputDataPush
 
 	for k, v := range c.claimsMap {
 		c2.claimsMap[k] = v

--- a/context_test.go
+++ b/context_test.go
@@ -141,6 +141,7 @@ func TestContext_Duplicate(t *testing.T) {
 		ctx.SetNext("next")
 		ctx.AddOutputCookies(cookies[0], cookies[1])
 		ctx.SetResponseWriter(rwriter)
+		ctx.SetDisableOutputDataPush(true)
 
 		Convey("When I call the Duplicate method", func() {
 
@@ -162,6 +163,7 @@ func TestContext_Duplicate(t *testing.T) {
 				So(ctx.outputCookies, ShouldResemble, ctx2.(*bcontext).outputCookies)
 				So(ctx.outputCookies, ShouldResemble, cookies)
 				So(ctx.responseWriter, ShouldEqual, rwriter)
+				So(ctx.disableOutputDataPush, ShouldEqual, ctx.disableOutputDataPush)
 			})
 		})
 	})

--- a/dispatchers.go
+++ b/dispatchers.go
@@ -189,9 +189,11 @@ func dispatchCreateOperation(
 		pusher(ctx.events...)
 	}
 
-	switch o := ctx.outputData.(type) {
-	case elemental.Identifiable:
-		pusher(elemental.NewEvent(elemental.EventCreate, o))
+	if !ctx.disableOutputDataPush {
+		switch o := ctx.outputData.(type) {
+		case elemental.Identifiable:
+			pusher(elemental.NewEvent(elemental.EventCreate, o))
+		}
 	}
 
 	audit(auditer, ctx, nil)
@@ -270,9 +272,11 @@ func dispatchUpdateOperation(
 		pusher(ctx.events...)
 	}
 
-	switch o := ctx.outputData.(type) {
-	case elemental.Identifiable:
-		pusher(elemental.NewEvent(elemental.EventUpdate, o))
+	if !ctx.disableOutputDataPush {
+		switch o := ctx.outputData.(type) {
+		case elemental.Identifiable:
+			pusher(elemental.NewEvent(elemental.EventUpdate, o))
+		}
 	}
 
 	audit(auditer, ctx, nil)
@@ -324,9 +328,11 @@ func dispatchDeleteOperation(
 		pusher(ctx.events...)
 	}
 
-	switch o := ctx.outputData.(type) {
-	case elemental.Identifiable:
-		pusher(elemental.NewEvent(elemental.EventDelete, o))
+	if !ctx.disableOutputDataPush {
+		switch o := ctx.outputData.(type) {
+		case elemental.Identifiable:
+			pusher(elemental.NewEvent(elemental.EventDelete, o))
+		}
 	}
 
 	audit(auditer, ctx, nil)
@@ -426,9 +432,11 @@ func dispatchPatchOperation(
 		pusher(ctx.events...)
 	}
 
-	switch o := ctx.outputData.(type) {
-	case elemental.Identifiable:
-		pusher(elemental.NewEvent(elemental.EventUpdate, o))
+	if !ctx.disableOutputDataPush {
+		switch o := ctx.outputData.(type) {
+		case elemental.Identifiable:
+			pusher(elemental.NewEvent(elemental.EventUpdate, o))
+		}
 	}
 
 	audit(auditer, ctx, nil)

--- a/dispatchers.go
+++ b/dispatchers.go
@@ -431,7 +431,7 @@ func dispatchPatchOperation(
 
 	return err
 }
-[]
+
 func dispatchInfoOperation(
 	ctx *bcontext,
 	processorFinder processorFinderFunc,

--- a/dispatchers.go
+++ b/dispatchers.go
@@ -189,11 +189,8 @@ func dispatchCreateOperation(
 		pusher(ctx.events...)
 	}
 
-	if !ctx.disableOutputDataPush {
-		switch o := ctx.outputData.(type) {
-		case elemental.Identifiable:
-			pusher(elemental.NewEvent(elemental.EventCreate, o))
-		}
+	if o, ok := ctx.outputData.(elemental.Identifiable); ok && !ctx.disableOutputDataPush {
+		pusher(elemental.NewEvent(elemental.EventCreate, o))
 	}
 
 	audit(auditer, ctx, nil)
@@ -272,11 +269,8 @@ func dispatchUpdateOperation(
 		pusher(ctx.events...)
 	}
 
-	if !ctx.disableOutputDataPush {
-		switch o := ctx.outputData.(type) {
-		case elemental.Identifiable:
-			pusher(elemental.NewEvent(elemental.EventUpdate, o))
-		}
+	if o, ok := ctx.outputData.(elemental.Identifiable); ok && !ctx.disableOutputDataPush {
+		pusher(elemental.NewEvent(elemental.EventUpdate, o))
 	}
 
 	audit(auditer, ctx, nil)
@@ -328,11 +322,8 @@ func dispatchDeleteOperation(
 		pusher(ctx.events...)
 	}
 
-	if !ctx.disableOutputDataPush {
-		switch o := ctx.outputData.(type) {
-		case elemental.Identifiable:
-			pusher(elemental.NewEvent(elemental.EventDelete, o))
-		}
+	if o, ok := ctx.outputData.(elemental.Identifiable); ok && !ctx.disableOutputDataPush {
+		pusher(elemental.NewEvent(elemental.EventDelete, o))
 	}
 
 	audit(auditer, ctx, nil)
@@ -432,18 +423,15 @@ func dispatchPatchOperation(
 		pusher(ctx.events...)
 	}
 
-	if !ctx.disableOutputDataPush {
-		switch o := ctx.outputData.(type) {
-		case elemental.Identifiable:
-			pusher(elemental.NewEvent(elemental.EventUpdate, o))
-		}
+	if o, ok := ctx.outputData.(elemental.Identifiable); ok && !ctx.disableOutputDataPush {
+		pusher(elemental.NewEvent(elemental.EventUpdate, o))
 	}
 
 	audit(auditer, ctx, nil)
 
 	return err
 }
-
+[]
 func dispatchInfoOperation(
 	ctx *bcontext,
 	processorFinder processorFinderFunc,

--- a/dispatchers_test.go
+++ b/dispatchers_test.go
@@ -387,6 +387,29 @@ func TestDispatchers_dispatchCreateOperation(t *testing.T) {
 
 		})
 
+		Convey("Given a processor that can handle ProcessCreate function with a context that disables output data push", func() {
+
+			var err error
+			processorFinder := func(identity elemental.Identity) (Processor, error) {
+				return &mockProcessor{
+					output: testmodel.NewList(),
+				}, nil
+			}
+
+			ctx.SetDisableOutputDataPush(true)
+
+			Convey("Then I should not panic no events should be pushed", func() {
+				So(func() {
+					err = dispatchCreateOperation(ctx, processorFinder, testmodel.Manager(), nil, nil, nil, pusher.Push, auditer, false, nil)
+				}, ShouldNotPanic)
+				So(err, ShouldBeNil)
+				So(ctx.InputData, ShouldNotBeNil)
+				So(auditer.GetCallCount(), ShouldEqual, 1)
+				So(len(pusher.events), ShouldEqual, 0)
+			})
+
+		})
+
 		Convey("Given a processor that can handle ProcessCreate function with a context output that contains a nil elemental.Identifiable", func() {
 
 			// notice how this is a type that satisfies the elemental.Identifiable interface, but it is not a nil interface!
@@ -613,7 +636,7 @@ func TestDispatchers_dispatchCreateOperation(t *testing.T) {
 		})
 	})
 
-	Convey("Given I have a processor that does not handle ProcessCreate function and an authorizer that is not authorize", t, func() {
+	Convey("Given I have a processor that does not handle ProcessCreate function and an authorizer that is not authorized", t, func() {
 		request := elemental.NewRequest()
 
 		processorFinder := func(identity elemental.Identity) (Processor, error) {
@@ -717,6 +740,28 @@ func TestDispatchers_dispatchUpdateOperation(t *testing.T) {
 				So(ctx.InputData, ShouldNotBeNil)
 				So(auditer.GetCallCount(), ShouldEqual, 1)
 				So(ctx.outputData, ShouldResemble, json.RawMessage("some random bytes!"))
+				So(len(pusher.events), ShouldEqual, 0)
+			})
+		})
+
+		Convey("Given I have a processor that handle ProcessUpdate function with a context that disables output data push", func() {
+
+			processorFinder := func(identity elemental.Identity) (Processor, error) {
+				return &mockProcessor{
+					output: testmodel.NewList(),
+				}, nil
+			}
+
+			ctx.SetDisableOutputDataPush(true)
+
+			Convey("Then I should not panic no events should be pushed", func() {
+				var err error
+				So(func() {
+					err = dispatchUpdateOperation(ctx, processorFinder, testmodel.Manager(), nil, nil, nil, pusher.Push, auditer, false, nil)
+				}, ShouldNotPanic)
+				So(err, ShouldBeNil)
+				So(ctx.InputData, ShouldNotBeNil)
+				So(auditer.GetCallCount(), ShouldEqual, 1)
 				So(len(pusher.events), ShouldEqual, 0)
 			})
 		})
@@ -1052,6 +1097,28 @@ func TestDispatchers_dispatchDeleteOperation(t *testing.T) {
 			})
 		})
 
+		Convey("Given I have a processor that handle ProcessDelete function with a context that disables output data push", func() {
+
+			processorFinder := func(identity elemental.Identity) (Processor, error) {
+				return &mockProcessor{
+					output: testmodel.NewList(),
+				}, nil
+			}
+
+			ctx.SetDisableOutputDataPush(true)
+
+			Convey("Then I should not panic no events should be pushed", func() {
+				var err error
+				So(func() {
+					err = dispatchDeleteOperation(ctx, processorFinder, nil, nil, pusher.Push, auditer, false, nil)
+				}, ShouldNotPanic)
+				So(err, ShouldBeNil)
+				So(ctx.InputData, ShouldNotBeNil)
+				So(auditer.GetCallCount(), ShouldEqual, 1)
+				So(len(pusher.events), ShouldEqual, 0)
+			})
+		})
+
 		Convey("Given I have a processor that handle ProcessDelete function with a context output that contains a nil elemental.Identifiable", func() {
 
 			// notice how this is a type that satisfies the elemental.Identifiable interface, but it is not a nil interface!
@@ -1281,6 +1348,28 @@ func TestDispatchers_dispatchPatchOperation(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(auditer.GetCallCount(), ShouldEqual, 1)
 				So(ctx.outputData, ShouldResemble, json.RawMessage("some random bytes!"))
+				So(len(pusher.events), ShouldEqual, 0)
+			})
+		})
+
+		Convey("Given I have a processor that handle ProcessPatch function with a context that disables output data push", func() {
+
+			processorFinder := func(identity elemental.Identity) (Processor, error) {
+				return &mockProcessor{
+					output: testmodel.NewList(),
+				}, nil
+			}
+
+			ctx.SetDisableOutputDataPush(true)
+
+			Convey("Then I should not panic no events should be pushed", func() {
+				var err error
+				So(func() {
+					err = dispatchPatchOperation(ctx, processorFinder, testmodel.Manager(), nil, nil, nil, pusher.Push, auditer, false, nil, nil)
+				}, ShouldNotPanic)
+				So(err, ShouldBeNil)
+				So(ctx.InputData, ShouldNotBeNil)
+				So(auditer.GetCallCount(), ShouldEqual, 1)
 				So(len(pusher.events), ShouldEqual, 0)
 			})
 		})

--- a/interfaces.go
+++ b/interfaces.go
@@ -113,6 +113,10 @@ type Context interface {
 	// the call will panic.
 	SetOutputData(interface{})
 
+	// SetDisableOutputDataPush will instruct the bahamut server to
+	// not automatically push the content of OutputData.
+	SetDisableOutputDataPush(bool)
+
 	// SetResponseWriter sets the ResponseWriter function to use to write the response back to the client.
 	//
 	// No additional operation or check will be performed by Bahamut. You are responsible


### PR DESCRIPTION

You can now use ctx.SetDisableOutputDataPush(true) to prevent Bahamut from pushing automatically the content of the context's OutputData.