### PR TITLE
new/upstreamer: Added an OptionLoadBasedBalancer

### DIFF
--- a/gateway/upstreamer/push/options.go
+++ b/gateway/upstreamer/push/options.go
@@ -99,10 +99,9 @@ var DefaulLoadBasedBalancerFunc LoadBasedBalancerFunc = func(load1, load2 float6
 // the current load of the service.
 func OptionLoadBasedBalancerFunc(loadBasedBalancerFunc LoadBasedBalancerFunc) Option {
 	return func(cfg *upstreamConfig) {
-		if loadBasedBalancerFunc != nil {
-			cfg.loadBasedBalancerFunc = loadBasedBalancerFunc
-		} else {
-			cfg.loadBasedBalancerFunc = DefaulLoadBasedBalancerFunc
+		if loadBasedBalancerFunc == nil {
+			panic("LoadBasedBalancerFunc must not be nil")
 		}
+		cfg.loadBasedBalancerFunc = loadBasedBalancerFunc
 	}
 }

--- a/gateway/upstreamer/push/options_test.go
+++ b/gateway/upstreamer/push/options_test.go
@@ -51,4 +51,8 @@ func Test_Options(t *testing.T) {
 		So(c.loadBasedBalancerFunc, ShouldEqual, fn)
 	})
 
+	Convey("Calling OptionLoadBasedBalancerFunc without func should panic", t, func() {
+		So(func() { OptionLoadBasedBalancerFunc(nil)(&c) }, ShouldPanicWith, "LoadBasedBalancerFunc must not be nil")
+	})
+
 }

--- a/gateway/upstreamer/push/options_test.go
+++ b/gateway/upstreamer/push/options_test.go
@@ -40,4 +40,10 @@ func Test_Options(t *testing.T) {
 		So(c.serviceTimeoutCheckInterval, ShouldEqual, time.Minute)
 	})
 
+	Convey("Calling OptionLoadBasedBalancer should work", t, func() {
+		OptionLoadBasedBalancer(5, nil)(&c)
+		So(c.minimumEndpointsForLoadSelection, ShouldEqual, 5)
+		So(c.loadThresholdFunc, ShouldNotBeNil)
+	})
+
 }

--- a/gateway/upstreamer/push/options_test.go
+++ b/gateway/upstreamer/push/options_test.go
@@ -40,10 +40,15 @@ func Test_Options(t *testing.T) {
 		So(c.serviceTimeoutCheckInterval, ShouldEqual, time.Minute)
 	})
 
-	Convey("Calling OptionLoadBasedBalancer should work", t, func() {
-		OptionLoadBasedBalancer(5, nil)(&c)
-		So(c.minimumEndpointsForLoadSelection, ShouldEqual, 5)
-		So(c.loadThresholdFunc, ShouldNotBeNil)
+	Convey("Calling OptionLoadBasedBalancerThreshold should work", t, func() {
+		OptionLoadBasedBalancerThreshold(5)(&c)
+		So(c.loadBasedBalancerThreshold, ShouldEqual, 5)
+	})
+
+	Convey("Calling OptionLoadBasedBalancerFunc should work", t, func() {
+		var fn LoadBasedBalancerFunc = func(a, b float64) bool { return a > b }
+		OptionLoadBasedBalancerFunc(fn)(&c)
+		So(c.loadBasedBalancerFunc, ShouldEqual, fn)
 	})
 
 }

--- a/gateway/upstreamer/push/upstreamer.go
+++ b/gateway/upstreamer/push/upstreamer.go
@@ -72,31 +72,32 @@ func (c *Upstreamer) Upstream(req *http.Request) (string, float64) {
 	epi1 := c.apis[identity][n1]
 	epi2 := c.apis[identity][n2]
 
+	epi1.RLock()
+	epi2.RLock()
+	defer epi1.RUnlock()
+	defer epi2.RUnlock()
+
+	// use load based seletion
+	if l >= c.config.minimumEndpointsForLoadSelection {
+
+		if c.config.loadThresholdFunc(epi1.lastLoad, epi2.lastLoad) {
+			return epi1.address, epi1.lastLoad
+		}
+		return epi2.address, epi2.lastLoad
+
+	}
+
+	// or use a random one
 	var address string
 	var load float64
 
-	epi1.RLock()
-	epi2.RLock()
-
-	switch {
-	case epi1.lastLoad == epi2.lastLoad:
-		if rand.Intn(2) == 0 {
-			address = epi1.address
-			load = epi1.lastLoad
-		} else {
-			address = epi2.address
-			load = epi2.lastLoad
-		}
-	case epi1.lastLoad < epi2.lastLoad:
+	if rand.Intn(2) == 0 {
 		address = epi1.address
 		load = epi1.lastLoad
-	default:
+	} else {
 		address = epi2.address
 		load = epi2.lastLoad
 	}
-
-	epi1.RUnlock()
-	epi2.RUnlock()
 
 	return address, load
 }

--- a/gateway/upstreamer/push/upstreamer_test.go
+++ b/gateway/upstreamer/push/upstreamer_test.go
@@ -204,7 +204,7 @@ func TestUpstreamUpstreamer(t *testing.T) {
 
 	Convey("Given I have an upstreamer with 3 registered apis with different loads", t, func() {
 
-		u := NewUpstreamer(nil, "topic", OptionLoadBasedBalancer(3, nil))
+		u := NewUpstreamer(nil, "topic", OptionLoadBasedBalancerThreshold(3))
 		u.apis = map[string][]*endpointInfo{
 			"cats": {
 				{
@@ -315,7 +315,7 @@ func TestUpstreamUpstreamer(t *testing.T) {
 
 	Convey("Given I have an upstreamer with 2 registered apis", t, func() {
 
-		u := NewUpstreamer(nil, "topic", OptionLoadBasedBalancer(2, nil))
+		u := NewUpstreamer(nil, "topic", OptionLoadBasedBalancerThreshold(2))
 		u.apis = map[string][]*endpointInfo{
 			"cats": {
 				{

--- a/gateway/upstreamer/push/upstreamer_test.go
+++ b/gateway/upstreamer/push/upstreamer_test.go
@@ -204,7 +204,7 @@ func TestUpstreamUpstreamer(t *testing.T) {
 
 	Convey("Given I have an upstreamer with 3 registered apis with different loads", t, func() {
 
-		u := NewUpstreamer(nil, "topic")
+		u := NewUpstreamer(nil, "topic", OptionLoadBasedBalancer(3, nil))
 		u.apis = map[string][]*endpointInfo{
 			"cats": {
 				{
@@ -315,7 +315,7 @@ func TestUpstreamUpstreamer(t *testing.T) {
 
 	Convey("Given I have an upstreamer with 2 registered apis", t, func() {
 
-		u := NewUpstreamer(nil, "topic")
+		u := NewUpstreamer(nil, "topic", OptionLoadBasedBalancer(2, nil))
 		u.apis = map[string][]*endpointInfo{
 			"cats": {
 				{


### PR DESCRIPTION
This option will allow us to decide when to apply the Load based balancing and allow custom implementation to be passed.

There is a flaw in the load based balancing as the load is reported by the endpoint every ping time (3s). It might be stale.
With small deployment, this is leads to very bad performances as all the traffic is going to one instance then to the other.

By setting a threshold to 6, the load based balancing is not done if the number of endpoint is < 6, instead a random one is picked. With that setup we triple at least the throughput performances.
