### PR TITLE
impr/gateway: Move the newLimitedListener higher un the chain so its at TCP level.

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -54,6 +54,10 @@ func New(listenAddr string, upstreamer Upstreamer, options ...Option) (Gateway, 
 		return nil, fmt.Errorf("unable build fast tcp listener: %s", err)
 	}
 
+	if cfg.tcpGlobalRateLimitingEnabled {
+		rootListener = newLimitedListener(rootListener, cfg.tcpGlobalRateLimitingCPS, cfg.tcpGlobalRateLimitingBurst)
+	}
+
 	if cfg.proxyProtocolEnabled {
 
 		sc, err := makeProxyProtocolSourceChecker(cfg.proxyProtocolSubnet)
@@ -82,10 +86,6 @@ func New(listenAddr string, upstreamer Upstreamer, options ...Option) (Gateway, 
 		} else {
 			listener = rootListener
 		}
-	}
-
-	if cfg.tcpGlobalRateLimitingEnabled {
-		listener = newLimitedListener(listener, cfg.tcpGlobalRateLimitingCPS, cfg.tcpGlobalRateLimitingBurst)
 	}
 
 	var serverLogger *log.Logger

--- a/gateway/listener.go
+++ b/gateway/listener.go
@@ -28,13 +28,8 @@ func (l *limitListener) Accept() (net.Conn, error) {
 	}
 
 	if !l.limiter.Allow() {
-		// We send a RST right away, no need to
-		// spend time doing a proper termination sequence
-		if t, ok := c.(*net.TCPConn); ok {
-			t.SetLinger(0)
-		}
-
 		c.Close() // nolint
 	}
+
 	return c, nil
 }


### PR DESCRIPTION
In order to do a fast efficient TCP rate limiting we are setting the SO_LINGER flag to 0 so we send a RST packed right away.

I had to move the newLimitedListener closer to the TCPListener as the tls.Conn cannot access the underlying net.TCPConn