### PR TITLE
CNS-340 - add ability to publish to specific subject hierarchies

### DIFF
--- a/bahamut.go
+++ b/bahamut.go
@@ -101,6 +101,10 @@ func New(options ...Option) Server {
 		zap.L().Warn("Push server is enabled but neither dispatching or publishing is. Use bahamut.OptPushPublishHandler() and/or bahamut.OptPushDispatchHandler()")
 	}
 
+	if !c.pushServer.enabled && c.pushServer.subjectHierarchiesEnabled {
+		zap.L().Warn("Push server subject hierarchies have been enabled, but no push server has been configured. Use bahamut.OptPushServer to configure a Push server.")
+	}
+
 	if (c.restServer.enabled || c.pushServer.enabled) && len(c.model.modelManagers) == 0 {
 		zap.L().Warn("No elemental.ModelManager is defined. Use bahamut.OptModel()")
 	}

--- a/config.go
+++ b/config.go
@@ -70,14 +70,15 @@ type config struct {
 	}
 
 	pushServer struct {
-		service         PubSubClient
-		topic           string
-		endpoint        string
-		dispatchHandler PushDispatchHandler
-		publishHandler  PushPublishHandler
-		enabled         bool
-		publishEnabled  bool
-		dispatchEnabled bool
+		service                   PubSubClient
+		topic                     string
+		endpoint                  string
+		dispatchHandler           PushDispatchHandler
+		publishHandler            PushPublishHandler
+		enabled                   bool
+		subjectHierarchiesEnabled bool
+		publishEnabled            bool
+		dispatchEnabled           bool
 	}
 
 	healthServer struct {

--- a/options.go
+++ b/options.go
@@ -172,9 +172,9 @@ func OptPushServer(service PubSubClient, topic string) Option {
 //   servers that are interested in receiving all events you publish to this topic would need to utilize subject wildcards.
 //
 //   See: https://docs.nats.io/nats-concepts/subjects#wildcards for more details.
-func OptPushServerEnableSubjectHierarchies(enabled bool) Option {
+func OptPushServerEnableSubjectHierarchies() Option {
 	return func(c *config) {
-		c.pushServer.subjectHierarchiesEnabled = enabled
+		c.pushServer.subjectHierarchiesEnabled = true
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -161,6 +161,23 @@ func OptPushServer(service PubSubClient, topic string) Option {
 	}
 }
 
+// OptPushServerEnableSubjectHierarchies will cause the push server to push to specific subject hierarchies under the configured
+// pub/sub topic you have chosen for your push server. This option has no effect if OptPushServer is not set.
+//
+// For example:
+//
+//   If the push server topic has been set to "global-events" and the server is about to push a "create" event w/ an identity
+//   value of "apples", enabling this option, would cause the push server to target a new publication to the subject
+//   "global-events.apples.create", INSTEAD OF "global-events". Consequently, as a result of this, any upstream push
+//   servers that are interested in receiving all events you publish to this topic would need to utilize subject wildcards.
+//
+//   See: https://docs.nats.io/nats-concepts/subjects#wildcards for more details.
+func OptPushServerEnableSubjectHierarchies(enabled bool) Option {
+	return func(c *config) {
+		c.pushServer.subjectHierarchiesEnabled = enabled
+	}
+}
+
 // OptPushEndpoint sets the endpoint to use for websocket channel.
 //
 // If unset, it fallsback to the default which is /events. This option

--- a/options_test.go
+++ b/options_test.go
@@ -105,6 +105,11 @@ func TestBahamut_Options(t *testing.T) {
 		So(c.pushServer.publishHandler, ShouldEqual, h)
 	})
 
+	Convey("Calling OptPushServerEnableSubjectHierarchies should work", t, func() {
+		OptPushServerEnableSubjectHierarchies()(&c)
+		So(c.pushServer.subjectHierarchiesEnabled, ShouldEqual, true)
+	})
+
 	Convey("Calling OptHealthServer should work", t, func() {
 		h := func() error { return nil }
 		OptHealthServer("1.2.3.4:123", h)(&c)


### PR DESCRIPTION
### Context

This PR adds an optional ability to publish to specific subject hierarchies of the configured topic of the push server via a new functional option `OptPushServerEnableSubjectHierarchies`.

The goal is to provide subscribers the ability to receive only events they care about instead of having them be required to add logic to ignore events they are not interested in.

**For example:**

If the push server topic has been set to `global-events` and the server is about to push a "create" event w/ an identity value of "apples", enabling this option, would cause the push server to target a new publication to the subject `global-events.apples.create`, **INSTEAD OF** `global-events`.


See https://docs.nats.io/nats-concepts/subjects for more details.

### Will be used to solve

- https://redlock.atlassian.net/browse/CNS-340
- https://redlock.atlassian.net/browse/CNS-94