### PR TITLE
impr/gateway: Add a way to preserve client IP when forwarded

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -141,9 +141,10 @@ func New(listenAddr string, upstreamer Upstreamer, options ...Option) (Gateway, 
 		forward.ErrorHandler(&errorHandler{}),
 		forward.Rewriter(
 			&requestRewriter{
-				blockOpenTracing: (!cfg.exposePrivateAPIs && cfg.blockOpenTracingHeaders),
-				private:          cfg.exposePrivateAPIs,
-				customRewriter:   cfg.requestRewriter,
+				blockOpenTracing:   (!cfg.exposePrivateAPIs && cfg.blockOpenTracingHeaders),
+				private:            cfg.exposePrivateAPIs,
+				customRewriter:     cfg.requestRewriter,
+				trustForwardHeader: cfg.trustForwardHeader,
 			},
 		),
 		forward.ResponseModifier(

--- a/gateway/options.go
+++ b/gateway/options.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -99,6 +100,7 @@ type gwconfig struct {
 	serverTLSConfig              *tls.Config
 	corsOrigin                   string
 	additionalCorsOrigin         map[string]struct{}
+	trustForwardHeader           bool
 }
 
 func newGatewayConfig() *gwconfig {
@@ -353,5 +355,14 @@ func OptionAdditionnalAllowedCORSOrigin(origins []string) Option {
 		for _, o := range origins {
 			cfg.additionalCorsOrigin[o] = struct{}{}
 		}
+	}
+}
+
+// OptionTrustForwardHeader configures if the gateway should strip
+// the X-Forwarded-For header or not.
+func OptionTrustForwardHeader(trust bool) Option {
+	fmt.Println("Keep", trust)
+	return func(cfg *gwconfig) {
+		cfg.trustForwardHeader = trust
 	}
 }

--- a/gateway/options.go
+++ b/gateway/options.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"crypto/tls"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -359,9 +358,8 @@ func OptionAdditionnalAllowedCORSOrigin(origins []string) Option {
 }
 
 // OptionTrustForwardHeader configures if the gateway should strip
-// the X-Forwarded-For header or not.
+// the X-Forwarded-For and X-Real-IP header or not.
 func OptionTrustForwardHeader(trust bool) Option {
-	fmt.Println("Keep", trust)
 	return func(cfg *gwconfig) {
 		cfg.trustForwardHeader = trust
 	}

--- a/gateway/options_test.go
+++ b/gateway/options_test.go
@@ -200,4 +200,11 @@ func Test_Options(t *testing.T) {
 		OptionUpstreamURLScheme("http")(c)
 		So(c.upstreamURLScheme, ShouldEqual, "http")
 	})
+
+	Convey("Calling OptionTrustForwardHeader should work", t, func() {
+		c := newGatewayConfig()
+		OptionTrustForwardHeader(true)(c)
+		So(c.trustForwardHeader, ShouldBeTrue)
+	})
+
 }

--- a/gateway/rewriters.go
+++ b/gateway/rewriters.go
@@ -11,9 +11,10 @@ import (
 )
 
 type requestRewriter struct {
-	customRewriter   RequestRewriter
-	blockOpenTracing bool
-	private          bool
+	customRewriter     RequestRewriter
+	blockOpenTracing   bool
+	private            bool
+	trustForwardHeader bool
 }
 
 func (s *requestRewriter) Rewrite(r *http.Request) {
@@ -38,8 +39,11 @@ func (s *requestRewriter) Rewrite(r *http.Request) {
 
 	// Will be rewritten by the forwarder,
 	// based on proxy protocol if enabled.
-	r.Header.Del("X-Forwarded-For")
-	r.Header.Del("X-Real-IP")
+	// unless trustForwardHeader is set.
+	if !s.trustForwardHeader {
+		r.Header.Del("X-Forwarded-For")
+		r.Header.Del("X-Real-IP")
+	}
 
 	if r.TLS != nil && len(r.TLS.PeerCertificates) == 1 {
 

--- a/gateway/rewriters_test.go
+++ b/gateway/rewriters_test.go
@@ -66,7 +66,7 @@ func Test_requestRewriter(t *testing.T) {
 			r, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1", nil)
 			r.TLS = &tls.ConnectionState{}
 
-			r.Header.Set("X-Forwarded-For ", "A")
+			r.Header.Set("X-Forwarded-For", "A")
 			r.Header.Set("X-Real-IP", "B")
 
 			rw.Rewrite(r)
@@ -75,6 +75,25 @@ func Test_requestRewriter(t *testing.T) {
 				So(r.Header.Get("X-Forwarded-For"), ShouldEqual, "")
 				So(r.Header.Get("X-Real-IP"), ShouldEqual, "")
 			})
+		})
+
+		Convey("When I call Rewrite it with custom X-Forwarded-For and X-Real-IP and trustForwardHeader is set", func() {
+
+			rw.trustForwardHeader = true
+
+			r, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1", nil)
+			r.TLS = &tls.ConnectionState{}
+
+			r.Header.Set("X-Forwarded-For", "A")
+			r.Header.Set("X-Real-IP", "B")
+
+			rw.Rewrite(r)
+
+			Convey("Then the response should be correct", func() {
+				So(r.Header.Get("X-Forwarded-For"), ShouldEqual, "A")
+				So(r.Header.Get("X-Real-IP"), ShouldEqual, "B")
+			})
+
 		})
 
 		Convey("When I call Rewrite it with a valid TLS client certificate", func() {


### PR DESCRIPTION
For service to service all going through an internal gateway, one might find useful to keep the original client IP.