### PR TITLE
new/gateway/push: added a global topic option for service ping

### DIFF
--- a/gateway/upstreamer/push/upstreamer_options.go
+++ b/gateway/upstreamer/push/upstreamer_options.go
@@ -24,6 +24,7 @@ type upstreamConfig struct {
 	randomizer                  Randomizer
 	tokenLimitingBurst          int
 	tokenLimitingRPS            rate.Limit
+	globalServiceTopic          string
 }
 
 func newUpstreamConfig() upstreamConfig {
@@ -137,5 +138,13 @@ func OptionUpstreamerTokenRateLimiting(rps rate.Limit, burst int) UpstreamerOpti
 		if cfg.tokenLimitingBurst <= 0 {
 			panic("burst cannot be <= 0")
 		}
+	}
+}
+
+// OptionUpstreamerGlobalServiceTopic sets the global topic that the gateway
+// will use to listen for service pings coming from global services.
+func OptionUpstreamerGlobalServiceTopic(topic string) UpstreamerOption {
+	return func(cfg *upstreamConfig) {
+		cfg.globalServiceTopic = topic
 	}
 }

--- a/gateway/upstreamer/push/upstreamer_options_test.go
+++ b/gateway/upstreamer/push/upstreamer_options_test.go
@@ -70,4 +70,9 @@ func Test_Options(t *testing.T) {
 		So(func() { OptionUpstreamerTokenRateLimiting(0, 2)(&c) }, ShouldPanicWith, `rps cannot be <= 0`)
 		So(func() { OptionUpstreamerTokenRateLimiting(1, 0)(&c) }, ShouldPanicWith, `burst cannot be <= 0`)
 	})
+
+	Convey("Calling OptionUpstreamerGlobalServiceTopic should work", t, func() {
+		OptionUpstreamerGlobalServiceTopic("global")(&c)
+		So(c.globalServiceTopic, ShouldEqual, "global")
+	})
 }


### PR DESCRIPTION
This option can be used to set an additional topic for services ping. This allows to use different topic to announce services that should be served globally