### PR TITLE
Check the codecov uploader's hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ artifacts
 remod.dev
 .remod
 dist
+
+/scripts/codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
 language: go
 
 go:
-- 1.13.x
-- 1.14.x
+  - 1.15.x
+  - 1.16.x
 
 env:
   global:
-  - GO111MODULE=on
+    - GO111MODULE=on
 
 before_install:
-- go get github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-- go get github.com/securego/gosec/cmd/gosec
+  - go get github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+  - go get github.com/securego/gosec/cmd/gosec
 
 script:
-- make
+  - make
 
 after_success:
-- bash <(curl -s https://codecov.io/bash)
+  - bash ./scripts/run-codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 
 go:
   - 1.15.x
-  - 1.16.x
 
 env:
   global:

--- a/scripts/run-codecov
+++ b/scripts/run-codecov
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+pushd "$HERE"
+
+# download codecov to ./codecov
+curl --silent --show-error -o "codecov" https://codecov.io/bash
+VERSION="$(grep 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2)"
+echo "codecov version: $VERSION"
+
+# download its hash (from another source) and print it for future reference
+curl --silent --show-error "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA512SUM" | grep codecov > codecov.sha
+cat -v codecov.sha
+
+# verify it has the hash published on GitHub
+shasum --algorithm 512 --check codecov.sha
+
+# run it
+bash codecov


### PR DESCRIPTION
(Note on this one I'm temporarily leaving off Go 1.16.)

https://redlock.atlassian.net/browse/CNS-2018