### PR TITLE
fixed: security audit findings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: go
 go:
   - 1.13.x
   - 1.14.x
+  - 1.15.x
+  - 1.16.x
 
 env:
   global:

--- a/authorizer/mtls/authorizer.go
+++ b/authorizer/mtls/authorizer.go
@@ -98,7 +98,10 @@ func CertificatesFromHeader(headerData string) (certs []*x509.Certificate, err e
 }
 
 // VerifierFunc is the type of function you can pass to do custom
-// verification on the certificates, like checking for the DN.
+// verification on the certificates, like checking against a certificate
+// revocation list. Note that CRL checking is not done by
+// Go when using x509.VerifyOptions. If you need need advanced CRL check
+// you need to implement it in a VerifierFunc.
 type VerifierFunc func(*x509.Certificate) bool
 
 // DeciderFunc is the type of function to pass to decide

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -136,7 +136,14 @@ func New(listenAddr string, upstreamer Upstreamer, options ...Option) (Gateway, 
 	var topProxyHandler http.Handler
 
 	corsOriginInjectorFunc := func(w http.ResponseWriter, r *http.Request) http.Header {
-		return injectCORSHeader(w.Header(), cfg.corsOrigin, cfg.additionalCorsOrigin, r.Header.Get("origin"), r.Method)
+		return injectCORSHeader(
+			w.Header(),
+			cfg.corsOrigin,
+			cfg.additionalCorsOrigin,
+			cfg.corsAllowCredentials,
+			r.Header.Get("origin"),
+			r.Method,
+		)
 	}
 
 	if s.forwarder, err = forward.New(
@@ -159,7 +166,14 @@ func New(listenAddr string, upstreamer Upstreamer, options ...Option) (Gateway, 
 				}
 
 				injectGeneralHeader(resp.Header)
-				injectCORSHeader(resp.Header, cfg.corsOrigin, cfg.additionalCorsOrigin, resp.Request.Header.Get("origin"), resp.Request.Method)
+				injectCORSHeader(
+					resp.Header,
+					cfg.corsOrigin,
+					cfg.additionalCorsOrigin,
+					cfg.corsAllowCredentials,
+					resp.Request.Header.Get("origin"),
+					resp.Request.Method,
+				)
 
 				if s.gatewayConfig.responseRewriter != nil {
 					if err := s.gatewayConfig.responseRewriter(resp); err != nil {
@@ -320,7 +334,14 @@ func (s *gateway) checkInterceptor(
 		}
 
 		return interceptor(w, r, writeError, func() {
-			injectCORSHeader(w.Header(), cfg.corsOrigin, cfg.additionalCorsOrigin, r.Header.Get("origin"), r.Method)
+			injectCORSHeader(
+				w.Header(),
+				cfg.corsOrigin,
+				cfg.additionalCorsOrigin,
+				cfg.corsAllowCredentials,
+				r.Header.Get("origin"),
+				r.Method,
+			)
 		})
 	}
 
@@ -331,7 +352,14 @@ func (s *gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if r.Method == http.MethodOptions {
 		h := w.Header()
-		injectCORSHeader(h, s.gatewayConfig.corsOrigin, s.gatewayConfig.additionalCorsOrigin, r.Header.Get("Origin"), r.Method)
+		injectCORSHeader(
+			h,
+			s.gatewayConfig.corsOrigin,
+			s.gatewayConfig.additionalCorsOrigin,
+			s.gatewayConfig.corsAllowCredentials,
+			r.Header.Get("Origin"),
+			r.Method,
+		)
 		w.WriteHeader(http.StatusOK) // nolint: errcheck
 		return
 	}
@@ -339,7 +367,14 @@ func (s *gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.gatewayConfig.maintenance {
 		h := w.Header()
 		h.Set("Content-Type", "application/msgpack, application/json")
-		injectCORSHeader(h, s.gatewayConfig.corsOrigin, s.gatewayConfig.additionalCorsOrigin, r.Header.Get("Origin"), r.Method)
+		injectCORSHeader(
+			h,
+			s.gatewayConfig.corsOrigin,
+			s.gatewayConfig.additionalCorsOrigin,
+			s.gatewayConfig.corsAllowCredentials,
+			r.Header.Get("Origin"),
+			r.Method,
+		)
 		writeError(w, r, errLocked)
 		return
 	}
@@ -385,7 +420,14 @@ HANDLE_INTERCEPTION:
 	if interceptAction == InterceptorActionStop {
 		// This has no incidence if the interceptor already wrote the header.
 		// In such case caller must call the corsInjector by himself.
-		injectCORSHeader(w.Header(), s.gatewayConfig.corsOrigin, s.gatewayConfig.additionalCorsOrigin, r.Header.Get("Origin"), r.Method)
+		injectCORSHeader(
+			w.Header(),
+			s.gatewayConfig.corsOrigin,
+			s.gatewayConfig.additionalCorsOrigin,
+			s.gatewayConfig.corsAllowCredentials,
+			r.Header.Get("Origin"),
+			r.Method,
+		)
 		return
 	}
 

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -313,14 +313,25 @@ func TestGateway(t *testing.T) {
 
 			gw.Start()
 
-			Convey("Then we I call existing ep 1", func() {
+			Convey("Then we I call existing ep 1 with origin", func() {
+				req, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1:7765/hello", nil)
+				req.Header.Set("origin", "orig")
+				resp, err := testclient.Do(req)
+				So(err, ShouldBeNil)
+				So(resp.StatusCode, ShouldEqual, 604)
+				So(resp.Header.Get("Access-Control-Allow-Origin"), ShouldEqual, "orig")
+				So(resp.Header.Get("Access-Control-Expose-Headers"), ShouldNotBeEmpty)
+				So(resp.Header.Get("Access-Control-Allow-Credentials"), ShouldNotBeEmpty)
+			})
+
+			Convey("Then we I call existing ep 1 without origin", func() {
 				req, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1:7765/hello", nil)
 				resp, err := testclient.Do(req)
 				So(err, ShouldBeNil)
 				So(resp.StatusCode, ShouldEqual, 604)
-				So(resp.Header.Get("Access-Control-Allow-Origin"), ShouldNotBeEmpty)
+				So(resp.Header.Get("Access-Control-Allow-Origin"), ShouldBeEmpty)
 				So(resp.Header.Get("Access-Control-Expose-Headers"), ShouldNotBeEmpty)
-				So(resp.Header.Get("Access-Control-Allow-Credentials"), ShouldNotBeEmpty)
+				So(resp.Header.Get("Access-Control-Allow-Credentials"), ShouldBeEmpty)
 			})
 		})
 

--- a/gateway/options.go
+++ b/gateway/options.go
@@ -61,7 +61,7 @@ const (
 )
 
 // CORSOriginMirror can be used with OptionAllowedCORSOrigin().
-// If set, the gateway will mirror any upcoming ORIGIN header
+// In this case, the gateway will mirror any upcoming ORIGIN header
 // in Access-Control-Allow-Origin response header.
 // NOTE: This should not be used in production.
 const CORSOriginMirror = "_mirror_"

--- a/gateway/options.go
+++ b/gateway/options.go
@@ -60,6 +60,12 @@ const (
 	InterceptorActionStop
 )
 
+// CORSOriginMirror can be used with OptionAllowedCORSOrigin().
+// If set, the gateway will mirror any upcoming ORIGIN header
+// in Access-Control-Allow-Origin response header.
+// NOTE: This should not be used in production.
+const CORSOriginMirror = "_mirror_"
+
 type gwconfig struct {
 	requestRewriter         RequestRewriter
 	responseRewriter        ResponseRewriter
@@ -103,6 +109,7 @@ type gwconfig struct {
 	upstreamEnableCompression    bool
 	serverTLSConfig              *tls.Config
 	corsOrigin                   string
+	corsAllowCredentials         bool
 	additionalCorsOrigin         map[string]struct{}
 	trustForwardHeader           bool
 }
@@ -110,7 +117,8 @@ type gwconfig struct {
 func newGatewayConfig() *gwconfig {
 	return &gwconfig{
 		additionalCorsOrigin:        map[string]struct{}{},
-		corsOrigin:                  "*",
+		corsOrigin:                  CORSOriginMirror,
+		corsAllowCredentials:        true,
 		prefixInterceptors:          map[string]InterceptorFunc{},
 		suffixInterceptors:          map[string]InterceptorFunc{},
 		exactInterceptors:           map[string]InterceptorFunc{},
@@ -347,12 +355,12 @@ func OptionUpstreamTLSConfig(tlsConfig *tls.Config) Option {
 }
 
 // OptionAllowedCORSOrigin sets allowed CORS origin.
-// If set to empty, or "*", the gateway will mirror
+// If set to CORSOriginMirror the gateway will mirror
 // whatever is set in the upcoming request Origin header.
 // This is not secure to be used in production
 // when a browser is calling the gateway.
 //
-// By default, it is set to "*"
+// By default, it is set to CORSOriginMirror.
 func OptionAllowedCORSOrigin(origin string) Option {
 	return func(cfg *gwconfig) {
 		cfg.corsOrigin = origin
@@ -367,6 +375,16 @@ func OptionAdditionnalAllowedCORSOrigin(origins []string) Option {
 		for _, o := range origins {
 			cfg.additionalCorsOrigin[o] = struct{}{}
 		}
+	}
+}
+
+// OptionCORSAllowCredentials sets if the header Access-Control-Allow-Credentials
+// should be set to true.
+//
+// By default, it is set to true.
+func OptionCORSAllowCredentials(allow bool) Option {
+	return func(cfg *gwconfig) {
+		cfg.corsAllowCredentials = allow
 	}
 }
 

--- a/gateway/options_test.go
+++ b/gateway/options_test.go
@@ -18,6 +18,8 @@ func Test_Options(t *testing.T) {
 		OptionEnableProxyProtocol(true, "10.0.0.0/0")(c)
 		So(c.proxyProtocolEnabled, ShouldEqual, true)
 		So(c.proxyProtocolSubnet, ShouldEqual, "10.0.0.0/0")
+		So(c.corsAllowCredentials, ShouldEqual, true)
+		So(c.corsOrigin, ShouldEqual, CORSOriginMirror)
 	})
 
 	Convey("Calling OptionTCPGobalRateLimiting should work", t, func() {
@@ -213,4 +215,9 @@ func Test_Options(t *testing.T) {
 		So(c.upstreamEnableCompression, ShouldBeTrue)
 	})
 
+	Convey("Calling OptionCORSAllowCredentials should work", t, func() {
+		c := newGatewayConfig()
+		OptionCORSAllowCredentials(false)(c)
+		So(c.corsAllowCredentials, ShouldBeFalse)
+	})
 }


### PR DESCRIPTION
- CORS: improve default and handling
- CORS: differentiate `*` and the `mirror` functionality
- CORS: add an option to control the general sending of`Access-Control-Allow-Credentials` header
- CORS: do not send `Access-Control-Allow-Credentials: true` is CORS origin is set to `*` or empty
- MTLS: add comment on how to implement CRL using the `VerifierFunc`
