### PR TITLE
fixed: oxy not forwarding IP info to ws backend

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -492,6 +492,11 @@ HANDLE_INTERCEPTION:
 			mm.RegisterWSConnection()
 		}
 
+		// We mark the request as a websocket so the
+		// rewriter can handle settinfg X-Forwarded-For header
+		// See rewriter for more info.
+		r.Header.Set(internalWSMarkingHeader, "1")
+
 		s.forwarder.ServeHTTP(w, r)
 
 		if mm := s.gatewayConfig.metricsManager; mm != nil {

--- a/gateway/rewriters_test.go
+++ b/gateway/rewriters_test.go
@@ -93,7 +93,38 @@ func Test_requestRewriter(t *testing.T) {
 				So(r.Header.Get("X-Forwarded-For"), ShouldEqual, "A")
 				So(r.Header.Get("X-Real-IP"), ShouldEqual, "B")
 			})
+		})
 
+		Convey("When I call Rewrite it with marked as ws internal", func() {
+
+			r, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1", nil)
+			r.TLS = &tls.ConnectionState{}
+
+			r.RemoteAddr = "1.1.1.1:11"
+			r.Header.Set(internalWSMarkingHeader, "1")
+
+			rw.Rewrite(r)
+
+			Convey("Then the response should be correct", func() {
+				So(r.Header.Get("X-Forwarded-For"), ShouldEqual, "1.1.1.1")
+				So(r.Header.Get("X-Real-IP"), ShouldEqual, "")
+			})
+		})
+
+		Convey("When I call Rewrite it with marked as ws internal with bad address", func() {
+
+			r, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1", nil)
+			r.TLS = &tls.ConnectionState{}
+
+			r.RemoteAddr = "oh no"
+			r.Header.Set(internalWSMarkingHeader, "1")
+
+			rw.Rewrite(r)
+
+			Convey("Then the response should be correct", func() {
+				So(r.Header.Get("X-Forwarded-For"), ShouldEqual, "")
+				So(r.Header.Get("X-Real-IP"), ShouldEqual, "")
+			})
 		})
 
 		Convey("When I call Rewrite it with a valid TLS client certificate", func() {


### PR DESCRIPTION
This patch adds a header marker in the incoming request that are planned to be upgraded to websockets. This marker will be used to decide to set X-Forwarded-For header on the internal request rewriter.

This will make sure the ws backend receives a correct X-Forwarded-For header