### PR TITLE
impr/tracing: Adding an option to only reports traces if they are in error

### DIFF
--- a/config.go
+++ b/config.go
@@ -139,6 +139,7 @@ type config struct {
 	opentracing struct {
 		tracer             opentracing.Tracer
 		excludedIdentities map[string]struct{}
+		onlyErrors         bool
 		traceCleaner       TraceCleaner
 	}
 

--- a/opentracing.go
+++ b/opentracing.go
@@ -162,10 +162,14 @@ func traceRequest(ctx context.Context, r *elemental.Request, tracer opentracing.
 	return trackingCtx
 }
 
-func finishTracing(ctx context.Context) {
+func finishTracing(ctx context.Context, onlyErrors bool) {
 
 	span := opentracing.SpanFromContext(ctx)
 	if span == nil {
+		return
+	}
+
+	if span.BaggageItem(errorsOnlyFlagBaggageItem) == "" && onlyErrors {
 		return
 	}
 

--- a/opentracing_test.go
+++ b/opentracing_test.go
@@ -14,6 +14,7 @@ package bahamut
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -320,7 +321,44 @@ func TestTracing_finishTracing(t *testing.T) {
 
 		Convey("When I call finishTracing", func() {
 
-			finishTracing(ctx)
+			finishTracing(ctx, false)
+
+			Convey("Then my span should be finished", func() {
+				So(ts.finished, ShouldBeTrue)
+			})
+		})
+
+		Convey("When I call finishTracing for error only", func() {
+
+			finishTracing(ctx, true)
+
+			Convey("Then my span should not be finished", func() {
+				So(ts.finished, ShouldBeFalse)
+			})
+		})
+	})
+
+	Convey("Given I have a context with a span in error", t, func() {
+
+		tracer := &mockTracer{}
+		ts := newMockSpan(tracer)
+
+		ctx := opentracing.ContextWithSpan(context.Background(), ts)
+
+		_ = processError(ctx, fmt.Errorf("an error"))
+
+		Convey("When I call finishTracing", func() {
+
+			finishTracing(ctx, false)
+
+			Convey("Then my span should be finished", func() {
+				So(ts.finished, ShouldBeTrue)
+			})
+		})
+
+		Convey("When I call finishTracing for error only", func() {
+
+			finishTracing(ctx, false)
 
 			Convey("Then my span should be finished", func() {
 				So(ts.finished, ShouldBeTrue)
@@ -335,7 +373,7 @@ func TestTracing_finishTracing(t *testing.T) {
 		Convey("When I call finishTracing", func() {
 
 			Convey("Then it should not panic", func() {
-				So(func() { finishTracing(ctx) }, ShouldNotPanic)
+				So(func() { finishTracing(ctx, false) }, ShouldNotPanic)
 			})
 		})
 	})

--- a/options.go
+++ b/options.go
@@ -493,6 +493,13 @@ func OptOpentracingExcludedIdentities(identities []elemental.Identity) Option {
 	}
 }
 
+// OptOpentracingTraceOnlyErrors only send trace on errors.
+func OptOpentracingTraceOnlyErrors(onlyErrors bool) Option {
+	return func(c *config) {
+		c.opentracing.onlyErrors = onlyErrors
+	}
+}
+
 // OptPostStartHook registers a function that will be executed right after the server is started.
 func OptPostStartHook(hook func(Server) error) Option {
 	return func(c *config) {

--- a/rest_server.go
+++ b/rest_server.go
@@ -365,7 +365,7 @@ func (a *restServer) makeHandler(handler handlerFunc) http.HandlerFunc {
 		}
 
 		ctx := traceRequest(req.Context(), request, a.cfg.opentracing.tracer, a.cfg.opentracing.excludedIdentities, a.cfg.opentracing.traceCleaner)
-		defer finishTracing(ctx)
+		defer finishTracing(ctx, a.cfg.opentracing.onlyErrors)
 
 		// Global rate limiting
 		if a.cfg.rateLimiting.rateLimiter != nil {

--- a/utils.go
+++ b/utils.go
@@ -24,6 +24,8 @@ import (
 	"go.aporeto.io/elemental"
 )
 
+const errorsOnlyFlagBaggageItem = "onlyErrors"
+
 func handleRecoveredPanic(ctx context.Context, r any, disablePanicRecovery bool) error {
 
 	if r == nil {
@@ -77,6 +79,7 @@ func processError(ctx context.Context, err error) (outError elemental.Errors) {
 		span.SetTag("error", true)
 		span.SetTag("status.code", outError.Code())
 		span.LogFields(log.Object("elemental.error", outError))
+		span.SetBaggageItem(errorsOnlyFlagBaggageItem, "true")
 	}
 
 	return outError


### PR DESCRIPTION
## Description

Added an option to only send traces when an error occurs.

## Motivation and Context

Sometimes is useless to send gazillions of traces when you only want to get the one in errors.

## How Has This Been Tested?

On production of course.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
